### PR TITLE
Standard config for orchestration service

### DIFF
--- a/assets/sample-orchestration-request.json
+++ b/assets/sample-orchestration-request.json
@@ -1,0 +1,24 @@
+{
+  "xml_message": "",
+  "xml_message_type": "ecr",
+  "configurations": {
+    "validation": {
+      "include_error_types": "error"
+    },
+    "convert_to_fhir": {
+      "root_template": "EICR",
+      "message_type": "ecr"
+    },
+    "standardization_and_geocoding": {
+      "geocode_method": "smarty",
+      "overwrite": "true",
+      "dob_format": ""
+    },
+    "message_parser": {
+      "message_format": "fhir",
+      "parsing_schema": "",
+      "parsing_schema_name": "",
+      "credential_manager": "azure"
+    }
+  }
+}

--- a/assets/sample-orchestration-request.json
+++ b/assets/sample-orchestration-request.json
@@ -1,6 +1,4 @@
 {
-  "message": "",
-  "message_type": "ecr",
   "configurations": {
     "validation": {
       "include_error_types": "error"

--- a/assets/sample-orchestration-request.json
+++ b/assets/sample-orchestration-request.json
@@ -1,13 +1,12 @@
 {
-  "xml_message": "",
-  "xml_message_type": "ecr",
+  "message": "",
+  "message_type": "ecr",
   "configurations": {
     "validation": {
       "include_error_types": "error"
     },
     "convert_to_fhir": {
-      "root_template": "EICR",
-      "message_type": "ecr"
+      "root_template": "EICR"
     },
     "standardization_and_geocoding": {
       "geocode_method": "smarty",


### PR DESCRIPTION
Howdy howdy, here's a draft of a standard config/base for a post request into the orchestration service.

One question already: Did I grab the right defaults for the fhir converter template and message type?

Assumptions I was working off of writing this:
- All sensitive things such as smarty creds are already env vars available in the service itself and don't need to be sent.
- The service will be holding onto the returns from each BB and pulling from them for the next post to a BB, e.g. the FHIR bundle returned from conversion will be passed to the post used for message parsing etc.
- Most things with a default I left off assuming it would default to the default, or gave an empty string

Stuff this is not yet built to do:
- Selection of which BBs to run and in what order.
- Make omelets.

Happy to take any and all feedback if folks were imagining something very different than this