### PR TITLE
Autoscale Kubernetes pods based on HTTP request traffic

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -95,11 +95,4 @@ jobs:
         run: |
           terraform init -backend-config=backend.tfvars
           terraform workspace select -or-create $TF_ENV
-          terraform apply -auto-approve -lock-timeout=30m \
-            -replace="module.shared.docker_tag.tag_for_azure[\"alerts\"]" \
-            -replace="module.shared.docker_tag.tag_for_azure[\"fhir-converter\"]" \
-            -replace="module.shared.docker_tag.tag_for_azure[\"ingestion\"]" \
-            -replace="module.shared.docker_tag.tag_for_azure[\"message-parser\"]" \
-            -replace="module.shared.docker_tag.tag_for_azure[\"tabulation\"]" \
-            -replace="module.shared.docker_tag.tag_for_azure[\"validation\"]" \
-            -replace="module.shared.docker_tag.tag_for_azure[\"record-linkage\"]"
+          terraform apply -auto-approve -lock-timeout=30m

--- a/terraform/implementation/backend.tf
+++ b/terraform/implementation/backend.tf
@@ -12,13 +12,13 @@ terraform {
       source  = "azure/azapi"
       version = "= 1.8.0"
     }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "= 2.10.1"
-    }
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = ">= 1.14.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "= 2.10.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/implementation/data.tf
+++ b/terraform/implementation/data.tf
@@ -17,3 +17,25 @@ data "azurerm_subnet" "appgwsubnet" {
   virtual_network_name = azurerm_virtual_network.aks_vnet.name
   resource_group_name  = var.resource_group_name
 }
+
+data "kubectl_path_documents" "keda_secret" {
+  pattern = "./manifests/kedaSecret.yaml"
+  vars = {
+    clientId       = "${base64encode(azuread_service_principal.aks.application_id)}"
+    clientPassword = "${base64encode(azuread_service_principal_password.aks.value)}"
+  }
+}
+
+data "kubectl_path_documents" "keda_trigger" {
+  pattern = "./manifests/kedaTriggerAuthentication.yaml"
+}
+
+data "kubectl_path_documents" "keda_scaled_object" {
+  pattern = "./manifests/kedaScaledObject.yaml"
+  vars = {
+    subscriptionId         = "${var.subscription_id}"
+    tenantId               = "${data.azurerm_client_config.current.tenant_id}"
+    resourceGroupName      = "${var.resource_group_name}"
+    applicationGatewayName = "${local.app_gateway_name}"
+  }
+}

--- a/terraform/implementation/data.tf
+++ b/terraform/implementation/data.tf
@@ -31,11 +31,13 @@ data "kubectl_path_documents" "keda_trigger" {
 }
 
 data "kubectl_path_documents" "keda_scaled_object" {
-  pattern = "./manifests/kedaScaledObject.yaml"
+  for_each = local.services
+  pattern  = "./manifests/kedaScaledObject.yaml"
   vars = {
     subscriptionId         = "${var.subscription_id}"
     tenantId               = "${data.azurerm_client_config.current.tenant_id}"
     resourceGroupName      = "${var.resource_group_name}"
     applicationGatewayName = "${local.app_gateway_name}"
+    serviceName            = each.key
   }
 }

--- a/terraform/implementation/keda.yaml
+++ b/terraform/implementation/keda.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-monitor-secrets
+data:
+  activeDirectoryClientId: ${clientId}
+  activeDirectoryClientPassword: ${clientPassword}
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: azure-monitor-trigger-auth
+spec:
+  secretTargetRef:
+    - parameter: activeDirectoryClientId
+      name: azure-monitor-secrets
+      key: activeDirectoryClientId
+    - parameter: activeDirectoryClientPassword
+      name: azure-monitor-secrets
+      key: activeDirectoryClientPassword
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: azure-monitor-scaler
+spec:
+  scaleTargetRef:
+    name: phdi-playground-dev-ingestion-ingestion-app
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  triggers:
+    - type: azure-monitor
+      metadata:
+        resourceURI: Microsoft.Network/applicationGateways/${applicationGatewayName}
+        tenantId: ${tenantId}
+        subscriptionId: ${subscriptionId}
+        resourceGroupName: ${resourceGroupName}
+        metricName: TotalRequests
+        metricNamespace: microsoft.network/applicationgateways
+        metricFilter: BackendSettingsPool eq 'pool-default-ingestion-service-8080-bp-8080~bp-default-ingestion-service-8080-8080-ingress'
+        metricAggregationInterval: "0:1:0"
+        metricAggregationType: Total
+        targetValue: "20"
+      authenticationRef:
+        name: azure-monitor-trigger-auth

--- a/terraform/implementation/keda.yaml
+++ b/terraform/implementation/keda.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: azure-monitor-secrets
+type: Opaque
 data:
   activeDirectoryClientId: ${clientId}
   activeDirectoryClientPassword: ${clientPassword}

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -179,6 +179,23 @@ resource "azurerm_application_gateway" "network" {
     backend_http_settings_name = local.http_setting_name
     priority                   = 1
   }
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+      ssl_certificate,
+      trusted_root_certificate,
+      frontend_port,
+      backend_address_pool,
+      backend_http_settings,
+      http_listener,
+      url_path_map,
+      request_routing_rule,
+      probe,
+      redirect_configuration,
+      ssl_policy,
+    ]
+  }
 }
 
 #### Kubernetes Service ####

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -188,7 +188,6 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   location            = var.location
   resource_group_name = var.resource_group_name
   dns_prefix          = local.aks_dns_prefix
-  depends_on          = [azurerm_application_gateway.network]
 
   default_node_pool {
     name            = "agentpool"
@@ -341,7 +340,7 @@ resource "azurerm_portal_dashboard" "pipeline_metrics" {
   name                = "app-gateway-metrics-${terraform.workspace}"
   resource_group_name = var.resource_group_name
   location            = var.location
-  depends_on          = [helm_release.building_blocks]
+  depends_on          = [azurerm_application_gateway.network, helm_release.building_blocks]
 
   tags = {
     source = "terraform"

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -363,15 +363,15 @@ resource "helm_release" "keda" {
 
 resource "kubectl_manifest" "keda_secret" {
   depends_on = [helm_release.keda, azuread_service_principal.aks, azuread_service_principal_password.aks]
-  yaml_body  = data.kubectl_path_documents.keda_secret.documents
+  yaml_body  = data.kubectl_path_documents.keda_secret.documents[0]
 }
 
 resource "kubectl_manifest" "keda_trigger" {
   depends_on = [kubectl_manifest.keda_secret]
-  yaml_body  = data.kubectl_path_documents.keda_trigger.documents
+  yaml_body  = data.kubectl_path_documents.keda_trigger.documents[0]
 }
 
 resource "kubectl_manifest" "keda_scaled_object" {
   depends_on = [kubectl_manifest.keda_trigger]
-  yaml_body  = data.kubectl_path_documents.keda_scaled_object.documents
+  yaml_body  = data.kubectl_path_documents.keda_scaled_object.documents[0]
 }

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -369,8 +369,8 @@ resource "helm_release" "keda" {
 data "kubectl_path_documents" "keda" {
   pattern = "./keda.yaml"
   vars = {
-    clientId               = "${azuread_service_principal.aks.application_id}"
-    clientPassword         = "${azuread_service_principal_password.aks.value}"
+    clientId               = "${base64encode(azuread_service_principal.aks.application_id)}"
+    clientPassword         = "${base64encode(azuread_service_principal_password.aks.value)}"
     subscriptionId         = "${var.subscription_id}"
     tenantId               = "${data.azurerm_client_config.current.tenant_id}"
     resourceGroupName      = "${var.resource_group_name}"

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -379,6 +379,7 @@ data "kubectl_path_documents" "keda" {
 }
 
 resource "kubectl_manifest" "keda" {
-  count     = length(data.kubectl_path_documents.keda.documents)
-  yaml_body = data.kubectl_path_documents.keda.documents[count.index]
+  depends_on = [helm_release.keda]
+  count      = length(data.kubectl_path_documents.keda.documents)
+  yaml_body  = data.kubectl_path_documents.keda.documents[count.index]
 }

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -76,11 +76,6 @@ resource "azurerm_role_assignment" "monitoring_reader" {
 }
 
 # SSH Key
-resource "random_pet" "ssh_key_name" {
-  prefix    = "ssh"
-  separator = ""
-}
-
 resource "azapi_resource_action" "ssh_public_key_gen" {
   type        = "Microsoft.Compute/sshPublicKeys@2022-11-01"
   resource_id = azapi_resource.ssh_public_key.id
@@ -92,7 +87,7 @@ resource "azapi_resource_action" "ssh_public_key_gen" {
 
 resource "azapi_resource" "ssh_public_key" {
   type      = "Microsoft.Compute/sshPublicKeys@2022-11-01"
-  name      = random_pet.ssh_key_name.id
+  name      = "phdi-playground-${terraform.workspace}-ssh-key"
   location  = var.location
   parent_id = data.azurerm_resource_group.rg.id
 }

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -360,7 +360,7 @@ resource "azurerm_portal_dashboard" "pipeline_metrics" {
 resource "helm_release" "keda" {
   name             = "keda"
   repository       = "https://kedacore.github.io/charts"
-  chart            = "kedacore/keda"
+  chart            = "keda"
   namespace        = "keda"
   create_namespace = true
   depends_on       = [azurerm_kubernetes_cluster.k8s]

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -371,6 +371,7 @@ resource "kubectl_manifest" "keda_trigger" {
 }
 
 resource "kubectl_manifest" "keda_scaled_object" {
+  for_each   = local.services
   depends_on = [kubectl_manifest.keda_trigger]
-  yaml_body  = data.kubectl_path_documents.keda_scaled_object.documents[0]
+  yaml_body  = data.kubectl_path_documents.keda_scaled_object[each.key].documents[0]
 }

--- a/terraform/implementation/manifests/kedaScaledObject.yaml
+++ b/terraform/implementation/manifests/kedaScaledObject.yaml
@@ -1,7 +1,7 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: azure-monitor-scaler
+  name: phdi-playground-dev-${serviceName}-scaler
 spec:
   scaleTargetRef:
     name: phdi-playground-dev-${serviceName}-${serviceName}-app

--- a/terraform/implementation/manifests/kedaScaledObject.yaml
+++ b/terraform/implementation/manifests/kedaScaledObject.yaml
@@ -14,11 +14,11 @@ spec:
         tenantId: ${tenantId}
         subscriptionId: ${subscriptionId}
         resourceGroupName: ${resourceGroupName}
-        metricName: TotalRequests
-        metricNamespace: microsoft.network/applicationgateways
+        metricName: AvgRequestCountPerHealthyHost
+        metricNamespace: Microsoft.Network/applicationgateways
         metricFilter: BackendSettingsPool eq 'pool-default-ingestion-service-8080-bp-8080~bp-default-ingestion-service-8080-8080-ingress'
         metricAggregationInterval: "0:1:0"
-        metricAggregationType: Total
+        metricAggregationType: Average
         targetValue: "20"
       authenticationRef:
         name: azure-monitor-trigger-auth

--- a/terraform/implementation/manifests/kedaScaledObject.yaml
+++ b/terraform/implementation/manifests/kedaScaledObject.yaml
@@ -1,25 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: azure-monitor-secrets
-type: Opaque
-data:
-  activeDirectoryClientId: ${clientId}
-  activeDirectoryClientPassword: ${clientPassword}
----
-apiVersion: keda.sh/v1alpha1
-kind: TriggerAuthentication
-metadata:
-  name: azure-monitor-trigger-auth
-spec:
-  secretTargetRef:
-    - parameter: activeDirectoryClientId
-      name: azure-monitor-secrets
-      key: activeDirectoryClientId
-    - parameter: activeDirectoryClientPassword
-      name: azure-monitor-secrets
-      key: activeDirectoryClientPassword
----
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/terraform/implementation/manifests/kedaScaledObject.yaml
+++ b/terraform/implementation/manifests/kedaScaledObject.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-monitor-scaler
 spec:
   scaleTargetRef:
-    name: phdi-playground-dev-ingestion-ingestion-app
+    name: phdi-playground-dev-${serviceName}-${serviceName}-app
   minReplicaCount: 1
   maxReplicaCount: 10
   triggers:
@@ -16,7 +16,7 @@ spec:
         resourceGroupName: ${resourceGroupName}
         metricName: AvgRequestCountPerHealthyHost
         metricNamespace: Microsoft.Network/applicationgateways
-        metricFilter: BackendSettingsPool eq 'pool-default-ingestion-service-8080-bp-8080~bp-default-ingestion-service-8080-8080-ingress'
+        metricFilter: BackendSettingsPool eq 'pool-default-${serviceName}-service-8080-bp-8080~bp-default-${serviceName}-service-8080-8080-ingress'
         metricAggregationInterval: "0:1:0"
         metricAggregationType: Average
         targetValue: "20"

--- a/terraform/implementation/manifests/kedaSecret.yaml
+++ b/terraform/implementation/manifests/kedaSecret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-monitor-secrets
+type: Opaque
+data:
+  activeDirectoryClientId: ${clientId}
+  activeDirectoryClientPassword: ${clientPassword}

--- a/terraform/implementation/manifests/kedaTriggerAuthentication.yaml
+++ b/terraform/implementation/manifests/kedaTriggerAuthentication.yaml
@@ -1,0 +1,12 @@
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: azure-monitor-trigger-auth
+spec:
+  secretTargetRef:
+    - parameter: activeDirectoryClientId
+      name: azure-monitor-secrets
+      key: activeDirectoryClientId
+    - parameter: activeDirectoryClientPassword
+      name: azure-monitor-secrets
+      key: activeDirectoryClientPassword


### PR DESCRIPTION
Resolves https://app.zenhub.com/workspaces/secret-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/phdi/798

This enables autoscaling using [KEDA](https://keda.sh/) (Kubernetes Event Driven Autoscaling), with their [Azure Monitor scaler](https://keda.sh/docs/2.11/scalers/azure-monitor/).

The metric used for scaling is `AvgRequestCountPerHealthyHost`, at 20/min. This might be kind of low, but I'm not really sure what a reasonable number would be. I'd imagine each pod would be able to handle at least 50-100 requests/min, though it may depend on the building block.