### PR TITLE
Add Terraform for AWS deploy including initial VPC

### DIFF
--- a/terraform/aws/implementation/backend.tf
+++ b/terraform/aws/implementation/backend.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.31.0"
+    }
+  }
+
+  backend "s3" {
+    key    = "remote_tfstate"
+    region = "us-east-1"
+  }
+}
+
+# Credentials should be provided by using the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
+provider "aws" {
+  region = "us-east-1"
+  default_tags {
+    tags = {
+      Owner       = "Skylight"
+      Environment = terraform.workspace
+    }
+  }
+}

--- a/terraform/aws/implementation/main.tf
+++ b/terraform/aws/implementation/main.tf
@@ -1,0 +1,4 @@
+module "vpc" {
+  source = "./modules/vpc"
+  region = var.region
+}

--- a/terraform/aws/implementation/modules/vpc/main.tf
+++ b/terraform/aws/implementation/modules/vpc/main.tf
@@ -1,0 +1,48 @@
+resource "aws_vpc" "vpc" {
+  cidr_block           = var.cidrs
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  instance_tenancy     = "default"
+}
+
+# Public A: 172.0.x.0/27
+resource "aws_subnet" "public_1a" {
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = "${var.region}a"
+  cidr_block        = replace(var.cidrs, "/24", "/27")
+}
+
+# Public B: 172.0.x.32/27
+resource "aws_subnet" "public_1b" {
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = "${var.region}b"
+  cidr_block        = replace(var.cidrs, "0/24", "32/27")
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc.id
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${terraform.workspace}-public"
+  }
+}
+
+resource "aws_route" "public" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+resource "aws_route_table_association" "public_1a" {
+  subnet_id      = aws_subnet.public_1a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_1b" {
+  subnet_id      = aws_subnet.public_1b.id
+  route_table_id = aws_route_table.public.id
+}

--- a/terraform/aws/implementation/modules/vpc/variables.tf
+++ b/terraform/aws/implementation/modules/vpc/variables.tf
@@ -1,0 +1,10 @@
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "cidrs" {
+  type        = string
+  default     = "172.0.1.0/24"
+  description = "Use to override the default environment CIDRs. Useful for feature deploys or local test environments."
+}

--- a/terraform/aws/implementation/variables.tf
+++ b/terraform/aws/implementation/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}

--- a/terraform/aws/setup/main.tf
+++ b/terraform/aws/setup/main.tf
@@ -1,0 +1,73 @@
+###########################################################################################
+#
+# This file creates the bare minimum infrastructure to start storing remote state.
+# It can't store its own remote state, so this file contains only one resource.
+#
+# In other words, do not apply this file multiple times, as it will fail due to lack of
+# state - it won't know it already created the resources.
+#
+###########################################################################################
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.31.0"
+    }
+  }
+}
+
+# Credentials should be provided by using the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = {
+      Owner       = "Skylight"
+      Environment = terraform.workspace
+    }
+  }
+}
+
+resource "aws_s3_bucket" "tfstate" {
+  bucket = "phdi-playground-tfstate-${terraform.workspace}"
+
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "default" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+  bucket = aws_s3_bucket.tfstate.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "default" {
+  bucket = aws_s3_bucket.tfstate.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Create a DynamoDB table for locking the state file
+resource "aws_dynamodb_table" "tfstate_lock" {
+  name         = "phdi-playground-tfstate-lock-${terraform.workspace}"
+  hash_key     = "LockID"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/terraform/aws/setup/variables.tf
+++ b/terraform/aws/setup/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
This adds Terraform setup code for deploying to AWS, and an initial implementation with just a VPC.

## Related Issue
[Fixes #](https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi/1030)