### PR TITLE
Add Cloudfront distribution to enable HTTPS

### DIFF
--- a/terraform/aws/implementation/main.tf
+++ b/terraform/aws/implementation/main.tf
@@ -42,9 +42,9 @@ module "eks" {
 }
 
 module "cloudfront" {
-  depends_on = [ module.eks ]
-  source = "./modules/cloudfront"
-  region = var.region
-  vpc_id = module.vpc.vpc_id
+  depends_on   = [module.eks]
+  source       = "./modules/cloudfront"
+  region       = var.region
+  vpc_id       = module.vpc.vpc_id
   alb_hostname = module.eks.alb_hostname
 }

--- a/terraform/aws/implementation/main.tf
+++ b/terraform/aws/implementation/main.tf
@@ -40,3 +40,11 @@ module "eks" {
   smarty_auth_id     = var.smarty_auth_id
   smarty_auth_token  = var.smarty_auth_token
 }
+
+module "cloudfront" {
+  depends_on = [ module.eks ]
+  source = "./modules/cloudfront"
+  region = var.region
+  vpc_id = module.vpc.vpc_id
+  alb_hostname = module.eks.alb_hostname
+}

--- a/terraform/aws/implementation/modules/cloudfront/main.tf
+++ b/terraform/aws/implementation/modules/cloudfront/main.tf
@@ -1,0 +1,51 @@
+resource "aws_cloudfront_distribution" "alb" {
+  origin {
+    domain_name = var.alb_hostname
+    origin_id   = "eks-alb"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "EKS ALB CloudFront Distribution"
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "eks-alb"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name = "eks-alb-cloudfront"
+  }
+}

--- a/terraform/aws/implementation/modules/cloudfront/variables.tf
+++ b/terraform/aws/implementation/modules/cloudfront/variables.tf
@@ -1,0 +1,14 @@
+variable "region" {
+  description = "The AWS region to deploy the CloudFront distribution"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The VPC ID to deploy the CloudFront distribution"
+  type        = string
+}
+
+variable "alb_hostname" {
+  description = "The DNS name of the ALB to use as the origin for the CloudFront distribution"
+  type        = string
+}

--- a/terraform/aws/implementation/modules/eks/data.tf
+++ b/terraform/aws/implementation/modules/eks/data.tf
@@ -341,3 +341,13 @@ data "kubectl_file_documents" "ingress" {
     terraform_workspace = terraform.workspace
   })
 }
+
+data "kubernetes_ingress_v1" "ingress" {
+  depends_on = [kubectl_manifest.ingress]
+  metadata {
+    name = "ingress"
+    annotations = {
+      "alb.ingress.kubernetes.io/group.name" = "phdi-playground-${terraform.workspace}"
+    }
+  }
+}

--- a/terraform/aws/implementation/modules/eks/outputs.tf
+++ b/terraform/aws/implementation/modules/eks/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_hostname" {
+  value = data.kubernetes_ingress_v1.ingress.status.0.load_balancer.0.ingress.0.hostname
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
This adds a Cloudfront distribution in front of the Application Load Balancer to enable HTTPS. You can now view the current deployment at https://d1pfxs4wepqgph.cloudfront.net/fhir-converter, etc.

## Related Issue
Fixes https://github.com/CDCgov/phdi/issues/1301

