### PR TITLE
update orchestration chart name

### DIFF
--- a/terraform/aws/implementation/modules/eks/variables.tf
+++ b/terraform/aws/implementation/modules/eks/variables.tf
@@ -29,7 +29,7 @@ variable "services_to_chart" {
     fhir-converter = "fhir-converter-chart",
     ingestion      = "ingestion-chart",
     message-parser = "message-parser-chart",
-    orchestration  = "orchestration",
+    orchestration  = "orchestration-chart",
     validation     = "validation-chart"
     ecr-viewer     = "ecr-viewer-chart"
   }

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -28,7 +28,7 @@ variable "services_to_chart" {
     ingestion      = "ingestion-chart",
     ingress        = "ingress-chart",
     message-parser = "message-parser-chart",
-    orchestration  = "orchestration",
+    orchestration  = "orchestration-chart",
     validation     = "validation-chart"
   }
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary
Making the helm chart naming convention consistent.  As a result, updating the `orchestration-chart` helm chart name in Azure and AWS.

## Related Issue
```
# module.eks.helm_release.building_blocks["orchestration"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
      ~ chart                      = "orchestration" -> "orchestration-chart"
        id                         = "phdi-playground-dev-orchestration"
      ~ metadata                   = [
          - {
              - app_version = "1.1.1"
              - chart       = "orchestration"
              - name        = "phdi-playground-dev-orchestration"
              - namespace   = "default"
              - revision    = 3
              - values      = jsonencode(
                    {
                      - ecrViewerUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ecr-viewer"
                      - fhirConverterUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/fhir-converter"
                      - image            = {
                          - tag = "v1.1.12"
                        }
                      - ingestionUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ingestion"
                      - messageParserUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/message-parser"
                      - smartyAuthId     = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken      = "AB5Bd7y9KGgxghGrD635"
                      - validationUrl    = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/validation"
                    }
                )
              - version     = "0.1.9"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-orchestration"
        # (25 unchanged attributes hidden)

        # (8 unchanged blocks hidden)
    }
```

## Additional Information
Anything else the review team should know?
Note: This is not related to a particular ticket.

