### PR TITLE
15 character limit for helm-charts, updating ecr-viewer and orchestra…

### DIFF
--- a/terraform/aws/implementation/modules/eks/variables.tf
+++ b/terraform/aws/implementation/modules/eks/variables.tf
@@ -29,9 +29,9 @@ variable "services_to_chart" {
     fhir-converter = "fhir-converter-chart",
     ingestion      = "ingestion-chart",
     message-parser = "message-parser-chart",
-    orchestration  = "orchestration-chart",
+    orchestration  = "orchestration",
     validation     = "validation-chart"
-    ecr-viewer     = "ecr-viewer-chart"
+    ecr-viewer     = "ecr-viewer"
   }
 }
 

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -28,7 +28,7 @@ variable "services_to_chart" {
     ingestion      = "ingestion-chart",
     ingress        = "ingress-chart",
     message-parser = "message-parser-chart",
-    orchestration  = "orchestration-chart",
+    orchestration  = "orchestration",
     validation     = "validation-chart"
   }
 }


### PR DESCRIPTION
…tion name

# PULL REQUEST

## Summary
Reverting changes to the helm chart name since there is a 15 character limit.  Therefore, the charts will continue to be named `orchestration` and `ecr-viewer` to avoid any errors.

## Related Issue
```
│ Error: 1 error occurred:
│       * Deployment.apps "phdi-playground-dev-ecr-viewer-ecr-viewer-app" is invalid: spec.template.spec.containers[0].ports[0].name: Invalid value: "ecr-viewer-chart": must be no more than 15 characters
```

## Additional Information
Anything else the review team should know?
Note: There is no ticket associated with this change or fix.
