### PR TITLE
add s3 role and attach to iam policies

### DIFF
--- a/terraform/aws/implementation/modules/s3/data.tf
+++ b/terraform/aws/implementation/modules/s3/data.tf
@@ -2,7 +2,7 @@ data "aws_iam_policy_document" "ecr_viewer_s3_policy" {
   statement {
     principals {
       type        = "AWS"
-      identifiers = ["ecrViewerPutPostGetS3Policy"]
+      identifiers = ["arn:aws:iam:339712971032:role/s3_role"]
     }
 
     actions = [
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "orchestration_s3_policy" {
   statement {
     principals {
       type        = "AWS"
-      identifiers = ["orchestrationPutAndPostS3Policy"]
+      identifiers = ["arn:aws:iam:339712971032:role/s3_role"]
     }
 
     actions = [
@@ -39,5 +39,16 @@ data "aws_iam_policy_document" "orchestration_s3_policy" {
       aws_s3_bucket.s3.arn,
       "${aws_s3_bucket.s3.arn}/*",
     ]
+  }
+}
+
+data "aws_iam_policy_document" "s3_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
   }
 }

--- a/terraform/aws/implementation/modules/s3/iam.tf
+++ b/terraform/aws/implementation/modules/s3/iam.tf
@@ -8,3 +8,9 @@ resource "aws_s3_bucket_policy" "allow_s3_access_for_orchestration" {
   bucket = aws_s3_bucket.s3.id
   policy = data.aws_iam_policy_document.orchestration_s3_policy.json
 }
+
+# s3 bucket role
+resource "aws_iam_role" "s3_role" {
+  name               = "S3AccessRole"
+  assume_role_policy = data.aws_iam_policy_document.s3_role_policy.json
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
What changes are being proposed?
* Adding s3_role and attaching it to the respective s3 iam policies.  Here is the terraform plan output 

```
Terraform will perform the following actions:

  # module.s3.data.aws_iam_policy_document.ecr_viewer_s3_policy will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "ecr_viewer_s3_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:GetObject",
              + "s3:GetObjectAcl",
              + "s3:PostObject",
              + "s3:PostObjectAcl",
              + "s3:PutObject",
              + "s3:PutObjectAcl",
            ]
          + resources = [
              + "arn:aws:s3:::processed-ecr-files-dev",
              + "arn:aws:s3:::processed-ecr-files-dev/*",
            ]

          + principals {
              + identifiers = [
                  + "arn:aws:iam:339712971032:role/s3_role",
                ]
              + type        = "AWS"
            }
        }
    }

  # module.s3.data.aws_iam_policy_document.orchestration_s3_policy will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "orchestration_s3_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:PostObject",
              + "s3:PostObjectAcl",
              + "s3:PutObject",
              + "s3:PutObjectAcl",
            ]
          + resources = [
              + "arn:aws:s3:::processed-ecr-files-dev",
              + "arn:aws:s3:::processed-ecr-files-dev/*",
            ]

          + principals {
              + identifiers = [
                  + "arn:aws:iam:339712971032:role/s3_role",
                ]
              + type        = "AWS"
            }
        }
    }

  # module.s3.data.aws_iam_policy_document.s3_role_policy will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "s3_role_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions = [
              + "sts:AssumeRole",
            ]

          + principals {
              + identifiers = [
                  + "s3.amazonaws.com",
                ]
              + type        = "Service"
            }
        }
    }

  # module.s3.aws_iam_role.s3_role will be created
  + resource "aws_iam_role" "s3_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = (known after apply)
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "S3AccessRole"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
      + unique_id             = (known after apply)
    }

  # module.s3.aws_s3_bucket_policy.allow_s3_access_for_ecr_viewer will be created
  + resource "aws_s3_bucket_policy" "allow_s3_access_for_ecr_viewer" {
      + bucket = "processed-ecr-files-dev"
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.s3.aws_s3_bucket_policy.allow_s3_access_for_orchestration will be created
  + resource "aws_s3_bucket_policy" "allow_s3_access_for_orchestration" {
      + bucket = "processed-ecr-files-dev"
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.eks.module.eks_blueprints_addons.module.karpenter.helm_release.this[0] will be updated in-place
  ~ resource "helm_release" "this" {
        id                         = "karpenter"
        name                       = "karpenter"
      ~ repository_password        = (sensitive value)
        # (30 unchanged attributes hidden)

        # (8 unchanged blocks hidden)
    }

Plan: 3 to add, 1 to change, 0 to destroy.
```

## Related Issue
Fixes # `MalformedPolicy: Invalid principal in policy` error

## Additional Information
Anything else the review team should know?

[//]: # (PR title: Remember to name your PR descriptively!)
