### PR TITLE
update iam roles for s3 and eks modules

### DIFF
--- a/terraform/aws/implementation/main.tf
+++ b/terraform/aws/implementation/main.tf
@@ -51,4 +51,5 @@ module "s3" {
   depends_on = [module.eks]
   source     = "./modules/s3"
   region     = var.region
+  eks_assume_role_policy = module.eks.eks_assume_role_policy
 }

--- a/terraform/aws/implementation/modules/eks/data.tf
+++ b/terraform/aws/implementation/modules/eks/data.tf
@@ -356,3 +356,28 @@ data "kubernetes_ingress_v1" "ingress" {
 data "aws_ecrpublic_authorization_token" "token" {
   provider = aws
 }
+
+data "aws_iam_policy_document" "eks_assume_role_policy" {
+  statement {
+    sid       = ""
+    effect    = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+  condition {
+    test     = "StringEquals" 
+    variable = "${local.oidc_provider}:aud" 
+    values   = ["sts.amazonaws.com"]
+  }
+
+  condition {
+    test     = "StringEquals" 
+    variable = "${local.oidc_provider}:sub" 
+    values   = ["system:serviceaccount:${local.namespace}:${local.service_account_name}"]
+  }
+  
+  principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_provider}"]
+    }
+  }
+}

--- a/terraform/aws/implementation/modules/eks/main.tf
+++ b/terraform/aws/implementation/modules/eks/main.tf
@@ -134,25 +134,7 @@ locals {
 
 resource "aws_iam_role" "eks_service_account" {
   name = "AmazonEKSLoadBalancerControllerRole"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Effect = "Allow"
-        Principal = {
-          Federated = "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_provider}"
-        }
-        Condition = {
-          StringEquals = {
-            "${local.oidc_provider}:aud" = "sts.amazonaws.com"
-            "${local.oidc_provider}:sub" = "system:serviceaccount:${local.namespace}:${local.service_account_name}"
-          }
-        }
-      },
-    ]
-  })
+  assume_role_policy = data.aws_iam_policy_document.eks_assume_role_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "load_balancer_controller" {

--- a/terraform/aws/implementation/modules/eks/outputs.tf
+++ b/terraform/aws/implementation/modules/eks/outputs.tf
@@ -1,3 +1,7 @@
 output "alb_hostname" {
   value = data.kubernetes_ingress_v1.ingress.status.0.load_balancer.0.ingress.0.hostname
 }
+
+output "eks_assume_role_policy" {
+  value = data.aws_iam_policy_document.eks_assume_role_policy.json
+}

--- a/terraform/aws/implementation/modules/s3/data.tf
+++ b/terraform/aws/implementation/modules/s3/data.tf
@@ -1,16 +1,7 @@
 data "aws_iam_policy_document" "ecr_viewer_s3_policy" {
   statement {
-
-    principals {
-      type        = "Service"
-      identifiers = ["s3.amazonaws.com"]
-    }
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam:339712971032:role/s3_role"]
-    }
-
+    sid       = ""
+    effect    = "Allow"
     actions = [
       "s3:PutObject",
       "s3:PutObjectAcl",
@@ -29,17 +20,8 @@ data "aws_iam_policy_document" "ecr_viewer_s3_policy" {
 
 data "aws_iam_policy_document" "orchestration_s3_policy" {
   statement {
-
-    principals {
-      type        = "Service"
-      identifiers = ["s3.amazonaws.com"]
-    }
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam:339712971032:role/s3_role"]
-    }
-
+    sid       = ""
+    effect    = "Allow"
     actions = [
       "s3:PutObject",
       "s3:PutObjectAcl",
@@ -51,16 +33,5 @@ data "aws_iam_policy_document" "orchestration_s3_policy" {
       aws_s3_bucket.s3.arn,
       "${aws_s3_bucket.s3.arn}/*",
     ]
-  }
-}
-
-data "aws_iam_policy_document" "s3_role_policy" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["s3.amazonaws.com"]
-    }
   }
 }

--- a/terraform/aws/implementation/modules/s3/data.tf
+++ b/terraform/aws/implementation/modules/s3/data.tf
@@ -34,4 +34,3 @@ data "aws_iam_policy_document" "orchestration_s3_policy" {
       "${aws_s3_bucket.s3.arn}/*",
     ]
   }
-}

--- a/terraform/aws/implementation/modules/s3/iam.tf
+++ b/terraform/aws/implementation/modules/s3/iam.tf
@@ -1,16 +1,33 @@
-# TODO iam permissions to speak with clear
-resource "aws_s3_bucket_policy" "allow_s3_access_for_ecr_viewer" {
-  bucket = aws_s3_bucket.s3.id
-  policy = data.aws_iam_policy_document.ecr_viewer_s3_policy.json
-}
-
-resource "aws_s3_bucket_policy" "allow_s3_access_for_orchestration" {
-  bucket = aws_s3_bucket.s3.id
-  policy = data.aws_iam_policy_document.orchestration_s3_policy.json
-}
-
 # s3 bucket role
-resource "aws_iam_role" "s3_role" {
-  name               = "S3AccessRole"
-  assume_role_policy = data.aws_iam_policy_document.s3_role_policy.json
+resource "aws_iam_role" "s3_role_for_ecr_viewer" {
+  name               = "S3AccessRoleForEcrViewer"
+  assume_role_policy = var.eks_assume_role_policy
+}
+
+resource "aws_iam_policy" "s3_bucket_ecr_viewer_policy" {
+  name        = "AWSS3IAMPolicyForEcrViewer"
+  description = "Policy for ECR-Viewer and S3 in DIBBS"
+  policy      = data.aws_iam_policy_document.ecr_viewer_s3_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "s3_bucket_ecr_viewer_policy" {
+  role       = aws_iam_role.s3_role_for_ecr_viewer.name
+  policy_arn = aws_iam_policy.s3_bucket_ecr_viewer_policy.arn
+}
+
+
+resource "aws_iam_role" "s3_role_for_orchestration" {
+  name               = "S3AccessRoleForOrchestration"
+  assume_role_policy = var.eks_assume_role_policy
+}
+
+resource "aws_iam_policy" "s3_bucket_orchestration_policy" {
+  name        = "AWSS3IAMPolicyForOrchestration"
+  description = "Policy for Orchestration and S3 in DIBBS"
+  policy      = data.aws_iam_policy_document.orchestration_s3_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "s3_bucket_orchestration_policy" {
+  role       = aws_iam_role.s3_role_for_orchestration.name
+  policy_arn = aws_iam_policy.s3_bucket_orchestration_policy.arn
 }

--- a/terraform/aws/implementation/modules/s3/variables.tf
+++ b/terraform/aws/implementation/modules/s3/variables.tf
@@ -7,3 +7,7 @@ variable "s3_name" {
   type    = string
   default = "processed-ecr-files"
 }
+
+variable "eks_assume_role_policy" {
+  type    = string
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
What changes are being proposed?
Updating the iam roles, policies and data for both s3 and eks modules.

```
Terraform will perform the following actions:

  # module.s3.data.aws_iam_policy_document.ecr_viewer_s3_policy will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "ecr_viewer_s3_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:GetObject",
              + "s3:GetObjectAcl",
              + "s3:PostObject",
              + "s3:PostObjectAcl",
              + "s3:PutObject",
              + "s3:PutObjectAcl",
            ]
          + effect    = "Allow"
          + resources = [
              + "arn:aws:s3:::processed-ecr-files-dev",
              + "arn:aws:s3:::processed-ecr-files-dev/*",
            ]
        }
    }

  # module.s3.data.aws_iam_policy_document.orchestration_s3_policy will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "orchestration_s3_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:PostObject",
              + "s3:PostObjectAcl",
              + "s3:PutObject",
              + "s3:PutObjectAcl",
            ]
          + effect    = "Allow"
          + resources = [
              + "arn:aws:s3:::processed-ecr-files-dev",
              + "arn:aws:s3:::processed-ecr-files-dev/*",
            ]
        }
    }

  # module.s3.aws_iam_policy.s3_bucket_ecr_viewer_policy will be created
  + resource "aws_iam_policy" "s3_bucket_ecr_viewer_policy" {
      + arn         = (known after apply)
      + description = "Policy for ECR-Viewer and S3 in DIBBS"
      + id          = (known after apply)
      + name        = "AWSS3IAMPolicyForEcrViewer"
      + name_prefix = (known after apply)
      + path        = "/"
      + policy      = (known after apply)
      + policy_id   = (known after apply)
      + tags_all    = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
    }

  # module.s3.aws_iam_policy.s3_bucket_orchestration_policy will be created
  + resource "aws_iam_policy" "s3_bucket_orchestration_policy" {
      + arn         = (known after apply)
      + description = "Policy for Orchestration and S3 in DIBBS"
      + id          = (known after apply)
      + name        = "AWSS3IAMPolicyForOrchestration"
      + name_prefix = (known after apply)
      + path        = "/"
      + policy      = (known after apply)
      + policy_id   = (known after apply)
      + tags_all    = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
    }

  # module.s3.aws_iam_role.s3_role will be destroyed
  # (because aws_iam_role.s3_role is not in configuration)
  - resource "aws_iam_role" "s3_role" {
      - arn                   = "arn:aws:iam::339712971032:role/S3AccessRole" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "s3.amazonaws.com"
                        }
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2024-03-01T21:49:32Z" -> null
      - force_detach_policies = false -> null
      - id                    = "S3AccessRole" -> null
      - managed_policy_arns   = [] -> null
      - max_session_duration  = 3600 -> null
      - name                  = "S3AccessRole" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - tags_all              = {
          - "Environment" = "dev"
          - "Owner"       = "Skylight"
        } -> null
      - unique_id             = "AROAU6GDYSEMCGQK5JYZU" -> null
    }

  # module.s3.aws_iam_role.s3_role_for_ecr_viewer will be created
  + resource "aws_iam_role" "s3_role_for_ecr_viewer" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringEquals = {
                              + "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:aud" = "sts.amazonaws.com"
                              + "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:sub" = "system:serviceaccount:kube-system:aws-load-balancer-controller"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::339712971032:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "S3AccessRoleForEcrViewer"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
      + unique_id             = (known after apply)
    }

  # module.s3.aws_iam_role.s3_role_for_orchestration will be created
  + resource "aws_iam_role" "s3_role_for_orchestration" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringEquals = {
                              + "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:aud" = "sts.amazonaws.com"
                              + "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:sub" = "system:serviceaccount:kube-system:aws-load-balancer-controller"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::339712971032:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "S3AccessRoleForOrchestration"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
      + unique_id             = (known after apply)
    }

  # module.s3.aws_iam_role_policy_attachment.s3_bucket_ecr_viewer_policy will be created
  + resource "aws_iam_role_policy_attachment" "s3_bucket_ecr_viewer_policy" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "S3AccessRoleForEcrViewer"
    }

  # module.s3.aws_iam_role_policy_attachment.s3_bucket_orchestration_policy will be created
  + resource "aws_iam_role_policy_attachment" "s3_bucket_orchestration_policy" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "S3AccessRoleForOrchestration"
    }

  # module.eks.module.eks_blueprints_addons.module.karpenter.helm_release.this[0] will be updated in-place
  ~ resource "helm_release" "this" {
        id                         = "karpenter"
        name                       = "karpenter"
      ~ repository_password        = (sensitive value)
        # (30 unchanged attributes hidden)

        # (8 unchanged blocks hidden)
    }

Plan: 6 to add, 1 to change, 1 to destroy.
```

## Related Issue
Fixes # EKS needs to be able to attach permissions to s3 bucket

## Additional Information
Anything else the review team should know?

