### PR TITLE
remove ecr-viewer and orchestration manifest and dependencies

### DIFF
--- a/terraform/aws/implementation/manifests/ecrViewerServiceAccount.yaml
+++ b/terraform/aws/implementation/manifests/ecrViewerServiceAccount.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ecr-viewer
-  annotations:
-    eks.amazonaws.com/role-arn: ${ecr_viewer_service_account_role_arn}

--- a/terraform/aws/implementation/manifests/orchestrationServiceAccount.yaml
+++ b/terraform/aws/implementation/manifests/orchestrationServiceAccount.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: orchestration
-  annotations:
-    eks.amazonaws.com/role-arn: ${orchestration_service_account_role_arn}

--- a/terraform/aws/implementation/modules/eks/data.tf
+++ b/terraform/aws/implementation/modules/eks/data.tf
@@ -329,18 +329,6 @@ data "kubectl_file_documents" "load_balancer_service_account" {
   })
 }
 
-data "kubectl_file_documents" "ecr_viewer_service_account" {
-  content = templatefile("./manifests/ecrViewerServiceAccount.yaml", {
-    ecr_viewer_service_account_role_arn = var.ecr_viewer_s3_role_arn
-  })
-}
-
-data "kubectl_file_documents" "orchestration_service_account" {
-  content = templatefile("./manifests/orchestrationServiceAccount.yaml", {
-    orchestration_service_account_role_arn = var.orchestration_s3_role_arn
-  })
-}
-
 data "aws_caller_identity" "current" {}
 
 data "kubectl_file_documents" "load_balancer_controller_crds" {

--- a/terraform/aws/implementation/modules/eks/main.tf
+++ b/terraform/aws/implementation/modules/eks/main.tf
@@ -146,14 +146,6 @@ resource "kubectl_manifest" "load_balancer_service_account" {
   yaml_body = data.kubectl_file_documents.load_balancer_service_account.documents[0]
 }
 
-resource "kubectl_manifest" "ecr_viewer_service_account" {
-  yaml_body = data.kubectl_file_documents.ecr_viewer_service_account.documents[0]
-}
-
-resource "kubectl_manifest" "orchestration_service_account" {
-  yaml_body = data.kubectl_file_documents.orchestration_service_account.documents[0]
-}
-
 # kubectl auth to EKS
 resource "terraform_data" "kubeconfig" {
   depends_on = [module.eks-cluster, kubectl_manifest.cluster_role_binding, kubectl_manifest.load_balancer_service_account]
@@ -228,7 +220,7 @@ resource "terraform_data" "wait_for_load_balancer_controller" {
 # Building blocks
 
 resource "helm_release" "building_blocks" {
-  depends_on      = [terraform_data.wait_for_load_balancer_controller, kubectl_manifest.ecr_viewer_service_account, kubectl_manifest.orchestration_service_account]
+  depends_on      = [terraform_data.wait_for_load_balancer_controller]
   for_each        = var.services_to_chart
   repository      = "https://cdcgov.github.io/phdi-charts/"
   name            = "phdi-playground-${terraform.workspace}-${each.key}"


### PR DESCRIPTION
# PULL REQUEST

## Summary
What changes are being proposed?
```
Terraform will perform the following actions:

  # module.eks.helm_release.building_blocks["ecr-viewer"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-ecr-viewer"
      ~ metadata                   = [
          - {
              - app_version = "1.1.11"
              - chart       = "ecr-viewer"
              - name        = "phdi-playground-dev-ecr-viewer"
              - namespace   = "default"
              - revision    = 2
              - values      = jsonencode(
                    {
                      - ecrViewerUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ecr-viewer"
                      - fhirConverterUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/fhir-converter"
                      - image            = {
                          - tag = "v1.2.1"
                        }
                      - ingestionUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ingestion"
                      - messageParserUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/message-parser"
                      - smartyAuthId     = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken      = "AB5Bd7y9KGgxghGrD635"
                      - validationUrl    = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/validation"
                    }
                )
              - version     = "0.1.0"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-ecr-viewer"
        # (26 unchanged attributes hidden)

      + set {
          + name  = "ecrViewerS3RoleArn"
          + value = (known after apply)
        }
      + set {
          + name  = "orchestrationS3RoleArn"
          + value = (known after apply)
        }

        # (8 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["fhir-converter"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-fhir-converter"
      ~ metadata                   = [
          - {
              - app_version = "1.1.1"
              - chart       = "fhir-converter-chart"
              - name        = "phdi-playground-dev-fhir-converter"
              - namespace   = "default"
              - revision    = 4
              - values      = jsonencode(
                    {
                      - ecrViewerUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ecr-viewer"
                      - fhirConverterUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/fhir-converter"
                      - image            = {
                          - tag = "v1.2.1"
                        }
                      - ingestionUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ingestion"
                      - messageParserUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/message-parser"
                      - smartyAuthId     = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken      = "AB5Bd7y9KGgxghGrD635"
                      - validationUrl    = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/validation"
                    }
                )
              - version     = "0.1.7"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-fhir-converter"
        # (26 unchanged attributes hidden)

      + set {
          + name  = "ecrViewerS3RoleArn"
          + value = (known after apply)
        }
      + set {
          + name  = "orchestrationS3RoleArn"
          + value = (known after apply)
        }

        # (8 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["ingestion"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-ingestion"
      ~ metadata                   = [
          - {
              - app_version = "1.1.1"
              - chart       = "ingestion-chart"
              - name        = "phdi-playground-dev-ingestion"
              - namespace   = "default"
              - revision    = 4
              - values      = jsonencode(
                    {
                      - ecrViewerUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ecr-viewer"
                      - fhirConverterUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/fhir-converter"
                      - image            = {
                          - tag = "v1.2.1"
                        }
                      - ingestionUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ingestion"
                      - messageParserUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/message-parser"
                      - smartyAuthId     = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken      = "AB5Bd7y9KGgxghGrD635"
                      - validationUrl    = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/validation"
                    }
                )
              - version     = "0.1.7"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-ingestion"
        # (26 unchanged attributes hidden)

      + set {
          + name  = "ecrViewerS3RoleArn"
          + value = (known after apply)
        }
      + set {
          + name  = "orchestrationS3RoleArn"
          + value = (known after apply)
        }

        # (8 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["message-parser"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-message-parser"
      ~ metadata                   = [
          - {
              - app_version = "1.1.1"
              - chart       = "message-parser-chart"
              - name        = "phdi-playground-dev-message-parser"
              - namespace   = "default"
              - revision    = 4
              - values      = jsonencode(
                    {
                      - ecrViewerUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ecr-viewer"
                      - fhirConverterUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/fhir-converter"
                      - image            = {
                          - tag = "v1.2.1"
                        }
                      - ingestionUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ingestion"
                      - messageParserUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/message-parser"
                      - smartyAuthId     = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken      = "AB5Bd7y9KGgxghGrD635"
                      - validationUrl    = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/validation"
                    }
                )
              - version     = "0.1.7"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-message-parser"
        # (26 unchanged attributes hidden)

      + set {
          + name  = "ecrViewerS3RoleArn"
          + value = (known after apply)
        }
      + set {
          + name  = "orchestrationS3RoleArn"
          + value = (known after apply)
        }

        # (8 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["orchestration"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-orchestration"
      ~ metadata                   = [
          - {
              - app_version = "1.1.1"
              - chart       = "orchestration"
              - name        = "phdi-playground-dev-orchestration"
              - namespace   = "default"
              - revision    = 6
              - values      = jsonencode(
                    {
                      - ecrViewerUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ecr-viewer"
                      - fhirConverterUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/fhir-converter"
                      - image            = {
                          - tag = "v1.2.1"
                        }
                      - ingestionUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ingestion"
                      - messageParserUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/message-parser"
                      - smartyAuthId     = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken      = "AB5Bd7y9KGgxghGrD635"
                      - validationUrl    = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/validation"
                    }
                )
              - version     = "0.1.9"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-orchestration"
        # (26 unchanged attributes hidden)

      + set {
          + name  = "ecrViewerS3RoleArn"
          + value = (known after apply)
        }
      + set {
          + name  = "orchestrationS3RoleArn"
          + value = (known after apply)
        }

        # (8 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["validation"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-validation"
      ~ metadata                   = [
          - {
              - app_version = "v1.1.1"
              - chart       = "validation-chart"
              - name        = "phdi-playground-dev-validation"
              - namespace   = "default"
              - revision    = 4
              - values      = jsonencode(
                    {
                      - ecrViewerUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ecr-viewer"
                      - fhirConverterUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/fhir-converter"
                      - image            = {
                          - tag = "v1.2.1"
                        }
                      - ingestionUrl     = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/ingestion"
                      - messageParserUrl = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/message-parser"
                      - smartyAuthId     = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken      = "AB5Bd7y9KGgxghGrD635"
                      - validationUrl    = "https://k8s-phdiplaygrounddev.us-east-1.elb.amazonaws.com/validation"
                    }
                )
              - version     = "0.1.7"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-validation"
        # (26 unchanged attributes hidden)

      + set {
          + name  = "ecrViewerS3RoleArn"
          + value = (known after apply)
        }
      + set {
          + name  = "orchestrationS3RoleArn"
          + value = (known after apply)
        }

        # (8 unchanged blocks hidden)
    }

  # module.eks.kubectl_manifest.load_balancer_service_account will be created
  + resource "kubectl_manifest" "load_balancer_service_account" {
      + api_version             = "v1"
      + apply_only              = false
      + force_conflicts         = false
      + force_new               = false
      + id                      = (known after apply)
      + kind                    = "ServiceAccount"
      + live_manifest_incluster = (sensitive value)
      + live_uid                = (known after apply)
      + name                    = "aws-load-balancer-controller"
      + namespace               = "kube-system"
      + server_side_apply       = false
      + uid                     = (known after apply)
      + validate_schema         = true
      + wait_for_rollout        = true
      + yaml_body               = (sensitive value)
      + yaml_body_parsed        = <<-EOT
            apiVersion: v1
            kind: ServiceAccount
            metadata:
              annotations:
                eks.amazonaws.com/role-arn: arn:aws:iam::339712971032:role/AmazonEKSLoadBalancerControllerRole
              labels:
                app.kubernetes.io/component: controller
                app.kubernetes.io/name: aws-load-balancer-controller
              name: aws-load-balancer-controller
              namespace: kube-system
        EOT
      + yaml_incluster          = (sensitive value)
    }

  # module.eks.kubectl_manifest.service_account will be destroyed
  # (because kubectl_manifest.service_account is not in configuration)
  - resource "kubectl_manifest" "service_account" {
      - api_version             = "v1" -> null
      - apply_only              = false -> null
      - force_conflicts         = false -> null
      - force_new               = false -> null
      - id                      = "/api/v1/namespaces/kube-system/serviceaccounts/aws-load-balancer-controller" -> null
      - kind                    = "ServiceAccount" -> null
      - live_manifest_incluster = (sensitive value) -> null
      - live_uid                = "0ac7dbd6-750b-4f27-aa84-598fd0864c06" -> null
      - name                    = "aws-load-balancer-controller" -> null
      - namespace               = "kube-system" -> null
      - server_side_apply       = false -> null
      - uid                     = "0ac7dbd6-750b-4f27-aa84-598fd0864c06" -> null
      - validate_schema         = true -> null
      - wait_for_rollout        = true -> null
      - yaml_body               = (sensitive value) -> null
      - yaml_body_parsed        = <<-EOT
            apiVersion: v1
            kind: ServiceAccount
            metadata:
              annotations:
                eks.amazonaws.com/role-arn: arn:aws:iam::339712971032:role/AmazonEKSLoadBalancerControllerRole
              labels:
                app.kubernetes.io/component: controller
                app.kubernetes.io/name: aws-load-balancer-controller
              name: aws-load-balancer-controller
              namespace: kube-system
        EOT -> null
      - yaml_incluster          = (sensitive value) -> null
    }

  # module.s3.aws_iam_policy.s3_bucket_ecr_viewer_policy will be created
  + resource "aws_iam_policy" "s3_bucket_ecr_viewer_policy" {
      + arn         = (known after apply)
      + description = "Policy for ECR-Viewer and S3 in DIBBS"
      + id          = (known after apply)
      + name        = "AWSS3IAMPolicyForEcrViewer"
      + name_prefix = (known after apply)
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:PutObjectAcl",
                          + "s3:PutObject",
                          + "s3:PostObjectAcl",
                          + "s3:PostObject",
                          + "s3:GetObjectAcl",
                          + "s3:GetObject",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::processed-ecr-files-dev/*",
                          + "arn:aws:s3:::processed-ecr-files-dev",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id   = (known after apply)
      + tags_all    = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
    }

  # module.s3.aws_iam_policy.s3_bucket_orchestration_policy will be created
  + resource "aws_iam_policy" "s3_bucket_orchestration_policy" {
      + arn         = (known after apply)
      + description = "Policy for Orchestration and S3 in DIBBS"
      + id          = (known after apply)
      + name        = "AWSS3IAMPolicyForOrchestration"
      + name_prefix = (known after apply)
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:PutObjectAcl",
                          + "s3:PutObject",
                          + "s3:PostObjectAcl",
                          + "s3:PostObject",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::processed-ecr-files-dev/*",
                          + "arn:aws:s3:::processed-ecr-files-dev",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id   = (known after apply)
      + tags_all    = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
    }

  # module.s3.aws_iam_role.s3_role will be destroyed
  # (because aws_iam_role.s3_role is not in configuration)
  - resource "aws_iam_role" "s3_role" {
      - arn                   = "arn:aws:iam::339712971032:role/S3AccessRole" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "s3.amazonaws.com"
                        }
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2024-03-01T21:49:32Z" -> null
      - force_detach_policies = false -> null
      - id                    = "S3AccessRole" -> null
      - managed_policy_arns   = [] -> null
      - max_session_duration  = 3600 -> null
      - name                  = "S3AccessRole" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - tags_all              = {
          - "Environment" = "dev"
          - "Owner"       = "Skylight"
        } -> null
      - unique_id             = "AROAU6GDYSEMCGQK5JYZU" -> null
    }

  # module.s3.aws_iam_role.s3_role_for_ecr_viewer will be created
  + resource "aws_iam_role" "s3_role_for_ecr_viewer" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringEquals = {
                              + "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:aud" = "sts.amazonaws.com"
                              + "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:sub" = "system:serviceaccount:kube-system:aws-load-balancer-controller"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::339712971032:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "S3AccessRoleForEcrViewer"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
      + unique_id             = (known after apply)
    }

  # module.s3.aws_iam_role.s3_role_for_orchestration will be created
  + resource "aws_iam_role" "s3_role_for_orchestration" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringEquals = {
                              + "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:aud" = "sts.amazonaws.com"
                              + "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:sub" = "system:serviceaccount:kube-system:aws-load-balancer-controller"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::339712971032:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "S3AccessRoleForOrchestration"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
      + unique_id             = (known after apply)
    }

  # module.s3.aws_iam_role_policy_attachment.s3_bucket_ecr_viewer_policy will be created
  + resource "aws_iam_role_policy_attachment" "s3_bucket_ecr_viewer_policy" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "S3AccessRoleForEcrViewer"
    }

  # module.s3.aws_iam_role_policy_attachment.s3_bucket_orchestration_policy will be created
  + resource "aws_iam_role_policy_attachment" "s3_bucket_orchestration_policy" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "S3AccessRoleForOrchestration"
    }

  # module.eks.module.eks_blueprints_addons.module.karpenter.helm_release.this[0] will be updated in-place
  ~ resource "helm_release" "this" {
        id                         = "karpenter"
        name                       = "karpenter"
      ~ repository_password        = (sensitive value)
        # (30 unchanged attributes hidden)

        # (8 unchanged blocks hidden)
    }

Plan: 7 to add, 7 to change, 2 to destroy.
```

## Related Issue
ticket [1272](https://app.zenhub.com/workspaces/streamline-ecr-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/phdi/1272)

