### PR TITLE
update ecrViewer ingress port to 3000

### DIFF
--- a/terraform/aws/implementation/manifests/ingress.yaml
+++ b/terraform/aws/implementation/manifests/ingress.yaml
@@ -53,4 +53,4 @@ spec:
               service:
                 name: phdi-playground-${terraform_workspace}-ecr-viewer-ecr-viewer-service
                 port:
-                  number: 8080
+                  number: 3000


### PR DESCRIPTION
# PULL REQUEST

## Summary
What changes are being proposed?

## Related Issue
Fixes the ecr-viewer because the ingress port was 8080 instead of 3000
```
Terraform will perform the following actions:

  # module.eks.data.kubernetes_ingress_v1.ingress will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "kubernetes_ingress_v1" "ingress" {
      + id     = (known after apply)
      + spec   = (known after apply)
      + status = (known after apply)

      + metadata {
          + annotations      = {
              + "alb.ingress.kubernetes.io/group.name" = "phdi-playground-dev"
            }
          + generation       = (known after apply)
          + name             = "ingress"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }
    }

  # module.eks.kubectl_manifest.ingress will be updated in-place
  ~ resource "kubectl_manifest" "ingress" {
        id                      = "/apis/networking.k8s.io/v1/namespaces/default/ingresses/ingress"
        name                    = "ingress"
      ~ yaml_body               = (sensitive value)
      ~ yaml_body_parsed        = <<-EOT
            apiVersion: networking.k8s.io/v1
            kind: Ingress
            metadata:
              annotations:
                alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:339712971032:certificate/ed68e703-100c-44b6-a2bf-56d43f8e870a
                alb.ingress.kubernetes.io/group.name: phdi-playground-dev
                alb.ingress.kubernetes.io/scheme: internet-facing
                alb.ingress.kubernetes.io/target-type: ip
              name: ingress
            spec:
              ingressClassName: alb
              rules:
              - http:
                  paths:
                  - backend:
                      service:
                        name: phdi-playground-dev-ingestion-ingestion-service
                        port:
                          number: 8080
                    path: /ingestion
                    pathType: Prefix
                  - backend:
                      service:
                        name: phdi-playground-dev-fhir-converter-fhir-converter-service
                        port:
                          number: 8080
                    path: /fhir-converter
                    pathType: Prefix
                  - backend:
                      service:
                        name: phdi-playground-dev-message-parser-message-parser-service
                        port:
                          number: 8080
                    path: /message-parser
                    pathType: Prefix
                  - backend:
                      service:
                        name: phdi-playground-dev-validation-validation-service
                        port:
                          number: 80
                    path: /validation
                    pathType: Prefix
                  - backend:
                      service:
                        name: phdi-playground-dev-orchestration-orchestration-service
                        port:
                          number: 8080
                    path: /orchestration
                    pathType: Prefix
                  - backend:
                      service:
                        name: phdi-playground-dev-ecr-viewer-ecr-viewer-service
                        port:
          -               number: 8080
          +               number: 3000
                    path: /ecr-viewer
                    pathType: Prefix
        EOT
        # (12 unchanged attributes hidden)
    }

  # module.eks.kubectl_manifest.load_balancer_service_account will be created
  + resource "kubectl_manifest" "load_balancer_service_account" {
      + api_version             = "v1"
      + apply_only              = false
      + force_conflicts         = false
      + force_new               = false
      + id                      = (known after apply)
      + kind                    = "ServiceAccount"
      + live_manifest_incluster = (sensitive value)
      + live_uid                = (known after apply)
      + name                    = "aws-load-balancer-controller"
      + namespace               = "kube-system"
      + server_side_apply       = false
      + uid                     = (known after apply)
      + validate_schema         = true
      + wait_for_rollout        = true
      + yaml_body               = (sensitive value)
      + yaml_body_parsed        = <<-EOT
            apiVersion: v1
            kind: ServiceAccount
            metadata:
              annotations:
                eks.amazonaws.com/role-arn: arn:aws:iam::339712971032:role/AmazonEKSLoadBalancerControllerRole
              labels:
                app.kubernetes.io/component: controller
                app.kubernetes.io/name: aws-load-balancer-controller
              name: aws-load-balancer-controller
              namespace: kube-system
        EOT
      + yaml_incluster          = (sensitive value)
    }

  # module.route53.aws_route53_record.alb will be updated in-place
  ~ resource "aws_route53_record" "alb" {
        id                               = "Z03589563KODV7RLSOEVV_dibbs.cloud_A"
        name                             = "dibbs.cloud"
        # (6 unchanged attributes hidden)

      ~ alias {
          ~ name                   = "k8s-phdiplaygrounddev-1f5c307cc0-429276606.us-east-1.elb.amazonaws.com" -> (known after apply)
            # (2 unchanged attributes hidden)
        }
    }

  # module.eks.module.eks_blueprints_addons.module.karpenter.helm_release.this[0] will be updated in-place
  ~ resource "helm_release" "this" {
        id                         = "karpenter"
        name                       = "karpenter"
      ~ repository_password        = (sensitive value)
        # (30 unchanged attributes hidden)

        # (8 unchanged blocks hidden)
    }

Plan: 1 to add, 3 to change, 0 to destroy.
```


## Additional Information
Anything else the review team should know?

[//]: # (PR title: Remember to name your PR descriptively!)
