### PR TITLE
removing orchestration services s3 access and updating ecrViewer

### DIFF
--- a/terraform/aws/implementation/main.tf
+++ b/terraform/aws/implementation/main.tf
@@ -31,22 +31,22 @@ module "vpc" {
 }
 
 module "eks" {
-  source                    = "./modules/eks"
-  region                    = var.region
-  eks_name                  = local.name
-  vpc_id                    = module.vpc.vpc_id
-  public_subnet_ids         = module.vpc.public_subnets
-  private_subnet_ids        = module.vpc.private_subnets
-  smarty_auth_id            = var.smarty_auth_id
-  smarty_auth_token         = var.smarty_auth_token
-  aws_acm_certificate_arn   = module.route53.aws_acm_certificate_arn
-  ecr_viewer_s3_role_arn    = module.s3.ecr_viewer_s3_role_arn
-  domain_name               = local.domain_name
-  ecr_bucket_name           = module.s3.ecr_bucket_name
-  enable_cognito            = var.enable_cognito
-  cognito_user_pool_arn     = module.cognito.cognito_user_pool_arn
-  cognito_client_id         = module.cognito.cognito_client_id
-  cognito_domain            = module.cognito.cognito_domain
+  source                  = "./modules/eks"
+  region                  = var.region
+  eks_name                = local.name
+  vpc_id                  = module.vpc.vpc_id
+  public_subnet_ids       = module.vpc.public_subnets
+  private_subnet_ids      = module.vpc.private_subnets
+  smarty_auth_id          = var.smarty_auth_id
+  smarty_auth_token       = var.smarty_auth_token
+  aws_acm_certificate_arn = module.route53.aws_acm_certificate_arn
+  ecr_viewer_s3_role_arn  = module.s3.ecr_viewer_s3_role_arn
+  domain_name             = local.domain_name
+  ecr_bucket_name         = module.s3.ecr_bucket_name
+  enable_cognito          = var.enable_cognito
+  cognito_user_pool_arn   = module.cognito.cognito_user_pool_arn
+  cognito_client_id       = module.cognito.cognito_client_id
+  cognito_domain          = module.cognito.cognito_domain
 }
 
 module "route53" {

--- a/terraform/aws/implementation/main.tf
+++ b/terraform/aws/implementation/main.tf
@@ -40,7 +40,6 @@ module "eks" {
   smarty_auth_id            = var.smarty_auth_id
   smarty_auth_token         = var.smarty_auth_token
   aws_acm_certificate_arn   = module.route53.aws_acm_certificate_arn
-  orchestration_s3_role_arn = module.s3.orchestration_s3_role_arn
   ecr_viewer_s3_role_arn    = module.s3.ecr_viewer_s3_role_arn
   domain_name               = local.domain_name
   ecr_bucket_name           = module.s3.ecr_bucket_name

--- a/terraform/aws/implementation/modules/eks/data.tf
+++ b/terraform/aws/implementation/modules/eks/data.tf
@@ -374,12 +374,6 @@ data "aws_iam_policy_document" "eks_assume_role_policy" {
     condition {
       test     = "StringEquals"
       variable = "${local.oidc_provider}:sub"
-      values   = ["system:serviceaccount:default:orchestration"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "${local.oidc_provider}:sub"
       values   = ["system:serviceaccount:default:ecr-viewer"]
     }
 

--- a/terraform/aws/implementation/modules/eks/main.tf
+++ b/terraform/aws/implementation/modules/eks/main.tf
@@ -282,7 +282,7 @@ resource "helm_release" "building_blocks" {
 
   set {
     name  = "image.tag"
-    value = "v1.2.6"
+    value = "v1.2.8"
   }
 
   set {
@@ -298,11 +298,6 @@ resource "helm_release" "building_blocks" {
   set {
     name  = "ecrViewerS3RoleArn"
     value = var.ecr_viewer_s3_role_arn
-  }
-
-  set {
-    name  = "orchestrationS3RoleArn"
-    value = var.orchestration_s3_role_arn
   }
 
   #  Values needed for orchestration service

--- a/terraform/aws/implementation/modules/eks/variables.tf
+++ b/terraform/aws/implementation/modules/eks/variables.tf
@@ -48,10 +48,6 @@ variable "aws_acm_certificate_arn" {
   description = "The ARN of the ACM certificate"
 }
 
-variable "orchestration_s3_role_arn" {
-  description = "The s3 Role ARN for the Orchestration Service"
-}
-
 variable "ecr_viewer_s3_role_arn" {
   description = "The s3 Role ARN for the ECR Viewer Service"
 }

--- a/terraform/aws/implementation/modules/s3/data.tf
+++ b/terraform/aws/implementation/modules/s3/data.tf
@@ -17,21 +17,3 @@ data "aws_iam_policy_document" "ecr_viewer_s3_policy" {
     ]
   }
 }
-
-data "aws_iam_policy_document" "orchestration_s3_policy" {
-  statement {
-    sid    = ""
-    effect = "Allow"
-    actions = [
-      "s3:PutObject",
-      "s3:PutObjectAcl",
-      "s3:PostObject",
-      "s3:PostObjectAcl",
-    ]
-
-    resources = [
-      aws_s3_bucket.s3.arn,
-      "${aws_s3_bucket.s3.arn}/*",
-    ]
-  }
-}

--- a/terraform/aws/implementation/modules/s3/iam.tf
+++ b/terraform/aws/implementation/modules/s3/iam.tf
@@ -14,20 +14,3 @@ resource "aws_iam_role_policy_attachment" "s3_bucket_ecr_viewer_policy" {
   role       = aws_iam_role.s3_role_for_ecr_viewer.name
   policy_arn = aws_iam_policy.s3_bucket_ecr_viewer_policy.arn
 }
-
-
-resource "aws_iam_role" "s3_role_for_orchestration" {
-  name               = "S3AccessRoleForOrchestration"
-  assume_role_policy = var.eks_assume_role_policy
-}
-
-resource "aws_iam_policy" "s3_bucket_orchestration_policy" {
-  name        = "AWSS3IAMPolicyForOrchestration"
-  description = "Policy for Orchestration and S3 in DIBBS"
-  policy      = data.aws_iam_policy_document.orchestration_s3_policy.json
-}
-
-resource "aws_iam_role_policy_attachment" "s3_bucket_orchestration_policy" {
-  role       = aws_iam_role.s3_role_for_orchestration.name
-  policy_arn = aws_iam_policy.s3_bucket_orchestration_policy.arn
-}

--- a/terraform/aws/implementation/modules/s3/outputs.tf
+++ b/terraform/aws/implementation/modules/s3/outputs.tf
@@ -1,7 +1,3 @@
-output "orchestration_s3_role_arn" {
-  value = aws_iam_role.s3_role_for_orchestration.arn
-}
-
 output "ecr_viewer_s3_role_arn" {
   value = aws_iam_role.s3_role_for_ecr_viewer.arn
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary
What changes are being proposed?
* removing orchestration service access to s3 
* adding ecrViewerUrl for the orchestration to access ecr-viewer

## Additional Information
Anything else the review team should know?
```
Terraform will perform the following actions:

  # module.cognito.aws_cognito_user.admin will be created
  + resource "aws_cognito_user" "admin" {
      + creation_date         = (known after apply)
      + enabled               = true
      + id                    = (known after apply)
      + last_modified_date    = (known after apply)
      + mfa_setting_list      = (known after apply)
      + preferred_mfa_setting = (known after apply)
      + status                = (known after apply)
      + sub                   = (known after apply)
      + temporary_password    = (sensitive value)
      + user_pool_id          = (known after apply)
      + username              = "admin"
    }

  # module.cognito.aws_cognito_user.dibbs will be created
  + resource "aws_cognito_user" "dibbs" {
      + creation_date         = (known after apply)
      + enabled               = true
      + id                    = (known after apply)
      + last_modified_date    = (known after apply)
      + mfa_setting_list      = (known after apply)
      + preferred_mfa_setting = (known after apply)
      + status                = (known after apply)
      + sub                   = (known after apply)
      + temporary_password    = (sensitive value)
      + user_pool_id          = (known after apply)
      + username              = "dibbs"
    }

  # module.cognito.aws_cognito_user_pool.pool will be created
  + resource "aws_cognito_user_pool" "pool" {
      + arn                        = (known after apply)
      + creation_date              = (known after apply)
      + custom_domain              = (known after apply)
      + deletion_protection        = "INACTIVE"
      + domain                     = (known after apply)
      + email_verification_message = (known after apply)
      + email_verification_subject = (known after apply)
      + endpoint                   = (known after apply)
      + estimated_number_of_users  = (known after apply)
      + id                         = (known after apply)
      + last_modified_date         = (known after apply)
      + mfa_configuration          = "OFF"
      + name                       = "phdi-playground-dev"
      + sms_verification_message   = (known after apply)
      + tags_all                   = {
          + "Environment" = "dev"
          + "Owner"       = "Skylight"
        }
    }

  # module.cognito.aws_cognito_user_pool_client.client will be created
  + resource "aws_cognito_user_pool_client" "client" {
      + access_token_validity                         = (known after apply)
      + allowed_oauth_flows                           = [
          + "code",
          + "implicit",
        ]
      + allowed_oauth_flows_user_pool_client          = true
      + allowed_oauth_scopes                          = [
          + "email",
          + "openid",
        ]
      + auth_session_validity                         = (known after apply)
      + callback_urls                                 = [
          + "https://dibbs.cloud/oauth2/idpresponse",
        ]
      + client_secret                                 = (sensitive value)
      + default_redirect_uri                          = (known after apply)
      + enable_propagate_additional_user_context_data = (known after apply)
      + enable_token_revocation                       = (known after apply)
      + explicit_auth_flows                           = (known after apply)
      + generate_secret                               = true
      + id                                            = (known after apply)
      + id_token_validity                             = (known after apply)
      + logout_urls                                   = (known after apply)
      + name                                          = "alb"
      + prevent_user_existence_errors                 = (known after apply)
      + read_attributes                               = (known after apply)
      + refresh_token_validity                        = (known after apply)
      + supported_identity_providers                  = [
          + "COGNITO",
        ]
      + user_pool_id                                  = (known after apply)
      + write_attributes                              = (known after apply)
    }

  # module.cognito.aws_cognito_user_pool_domain.domain will be created
  + resource "aws_cognito_user_pool_domain" "domain" {
      + aws_account_id                  = (known after apply)
      + cloudfront_distribution         = (known after apply)
      + cloudfront_distribution_arn     = (known after apply)
      + cloudfront_distribution_zone_id = (known after apply)
      + domain                          = "phdi-playground-dev"
      + id                              = (known after apply)
      + s3_bucket                       = (known after apply)
      + user_pool_id                    = (known after apply)
      + version                         = (known after apply)
    }

  # module.eks.data.kubectl_file_documents.load_balancer_service_account will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "kubectl_file_documents" "load_balancer_service_account" {
      + content   = <<-EOT
            apiVersion: v1
            kind: ServiceAccount
            metadata:
              labels:
                app.kubernetes.io/component: controller
                app.kubernetes.io/name: aws-load-balancer-controller
              name: aws-load-balancer-controller
              namespace: kube-system
              annotations:
                eks.amazonaws.com/role-arn: arn:aws:iam::339712971032:role/AmazonEKSLoadBalancerControllerRole
        EOT
      + documents = (known after apply)
      + id        = (known after apply)
      + manifests = (known after apply)
    }

  # module.eks.aws_iam_role.eks_service_account will be updated in-place
  ~ resource "aws_iam_role" "eks_service_account" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringEquals = {
                              ~ "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:sub" = [
                                  - "system:serviceaccount:default:orchestration",
                                    "system:serviceaccount:kube-system:aws-load-balancer-controller",
                                    # (1 unchanged element hidden)
                                ]
                                # (1 unchanged attribute hidden)
                            }
                        }
                        # (3 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id                    = "AmazonEKSLoadBalancerControllerRole"
        name                  = "AmazonEKSLoadBalancerControllerRole"
        tags                  = {}
        # (8 unchanged attributes hidden)
    }

  # module.eks.helm_release.building_blocks["ecr-viewer"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-ecr-viewer"
      ~ metadata                   = [
          - {
              - app_version = ""
              - chart       = "ecr-viewer"
              - name        = "phdi-playground-dev-ecr-viewer"
              - namespace   = "default"
              - revision    = 2
              - values      = jsonencode(
                    {
                      - ecrBucketName          = "processed-ecr-files-dev"
                      - ecrViewerS3RoleArn     = "arn:aws:iam::339712971032:role/S3AccessRoleForEcrViewer"
                      - ecrViewerUrl           = "https://dibbs.cloud/ecr-viewer"
                      - fhirConverterUrl       = "https://dibbs.cloud/fhir-converter"
                      - image                  = {
                          - tag = "v1.2.6"
                        }
                      - ingestionUrl           = "https://dibbs.cloud/ingestion"
                      - messageParserUrl       = "https://dibbs.cloud/message-parser"
                      - nbsPubKey              = <<-EOT
                            -----BEGIN PUBLIC KEY-----
                            MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAqjrH9PprQCB5dX15zYfd
                            S6K2ezNi/ZOu8vKEhQuLqwHACy1iUt1Yyp2PZLIV7FVDgBHMMVWPVx3GJ2wEyaJw
                            MHkv6XNpUpWLhbs0V1T7o/OZfEIqcNua07OEoBxX9vhKIHtaksWdoMyKRXQJz0js
                            oWpawfOWxETnLqGvybT4yvY2RJhquTXLcLu90L4LdvIkADIZshaOtAU/OwI5ATcb
                            fE3ip15E6jIoUm7FAtfRiuncpI5l/LJPP6fvwf8QCbbUJBZklLqcUuf4qe/L/nIq
                            pIONb8KZFWPhnGeRZ9bwIcqYWt3LAAshQLSGEYl2PGXaqbkUD2XLETSKDjisxd0g
                            9j8bIMPgBKi+dBYcmBZnR7DxJe+vEDDw8prHG/+HRy5fim/BcibTKnIl8PR5yqHa
                            mWQo7N+xXhILdD9e33KLRgbg97+erHqvHlNMdwDhAfrBT+W6GCdPwp3cePPsbhsc
                            oGSHOUDhzyAujr0J8h5WmZDGUNWjGzWqubNZD8dBXB8x+9dDoWhfM82nw0pvAeKf
                            wJodvn3Qo8/S5hxJ6HyGkUTANKN8IxWh/6R5biET5BuztZP6jfPEaOAnt6sq+C38
                            hR9rUr59dP2BTlcJ19ZXobLwuJEa81S5BrcbDwYNOAzC8jl2EV1i4bQIwJJaY27X
                            Iynom6unaheZpS4DFIh2w9UCAwEAAQ==
                            -----END PUBLIC KEY-----
                        EOT
                      - orchestrationS3RoleArn = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration"
                      - smartyAuthId           = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken            = "AB5Bd7y9KGgxghGrD635"
                      - source                 = "s3"
                      - validationUrl          = "https://dibbs.cloud/validation"
                    }
                )
              - version     = "0.1.5"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-ecr-viewer"
        # (26 unchanged attributes hidden)

      - set {
          - name  = "image.tag" -> null
          - value = "v1.2.6" -> null
        }
      - set {
          - name  = "orchestrationS3RoleArn" -> null
          - value = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration" -> null
        }
      + set {
          + name  = "image.tag"
          + value = "v1.2.8"
        }

        # (11 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["fhir-converter"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-fhir-converter"
      ~ metadata                   = [
          - {
              - app_version = "1.1.1"
              - chart       = "fhir-converter-chart"
              - name        = "phdi-playground-dev-fhir-converter"
              - namespace   = "default"
              - revision    = 14
              - values      = jsonencode(
                    {
                      - ecrBucketName          = "processed-ecr-files-dev"
                      - ecrViewerS3RoleArn     = "arn:aws:iam::339712971032:role/S3AccessRoleForEcrViewer"
                      - ecrViewerUrl           = "https://dibbs.cloud/ecr-viewer"
                      - fhirConverterUrl       = "https://dibbs.cloud/fhir-converter"
                      - image                  = {
                          - tag = "v1.2.6"
                        }
                      - ingestionUrl           = "https://dibbs.cloud/ingestion"
                      - messageParserUrl       = "https://dibbs.cloud/message-parser"
                      - nbsPubKey              = <<-EOT
                            -----BEGIN PUBLIC KEY-----
                            MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAqjrH9PprQCB5dX15zYfd
                            S6K2ezNi/ZOu8vKEhQuLqwHACy1iUt1Yyp2PZLIV7FVDgBHMMVWPVx3GJ2wEyaJw
                            MHkv6XNpUpWLhbs0V1T7o/OZfEIqcNua07OEoBxX9vhKIHtaksWdoMyKRXQJz0js
                            oWpawfOWxETnLqGvybT4yvY2RJhquTXLcLu90L4LdvIkADIZshaOtAU/OwI5ATcb
                            fE3ip15E6jIoUm7FAtfRiuncpI5l/LJPP6fvwf8QCbbUJBZklLqcUuf4qe/L/nIq
                            pIONb8KZFWPhnGeRZ9bwIcqYWt3LAAshQLSGEYl2PGXaqbkUD2XLETSKDjisxd0g
                            9j8bIMPgBKi+dBYcmBZnR7DxJe+vEDDw8prHG/+HRy5fim/BcibTKnIl8PR5yqHa
                            mWQo7N+xXhILdD9e33KLRgbg97+erHqvHlNMdwDhAfrBT+W6GCdPwp3cePPsbhsc
                            oGSHOUDhzyAujr0J8h5WmZDGUNWjGzWqubNZD8dBXB8x+9dDoWhfM82nw0pvAeKf
                            wJodvn3Qo8/S5hxJ6HyGkUTANKN8IxWh/6R5biET5BuztZP6jfPEaOAnt6sq+C38
                            hR9rUr59dP2BTlcJ19ZXobLwuJEa81S5BrcbDwYNOAzC8jl2EV1i4bQIwJJaY27X
                            Iynom6unaheZpS4DFIh2w9UCAwEAAQ==
                            -----END PUBLIC KEY-----
                        EOT
                      - orchestrationS3RoleArn = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration"
                      - smartyAuthId           = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken            = "AB5Bd7y9KGgxghGrD635"
                      - source                 = "s3"
                      - validationUrl          = "https://dibbs.cloud/validation"
                    }
                )
              - version     = "0.1.7"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-fhir-converter"
        # (26 unchanged attributes hidden)

      - set {
          - name  = "image.tag" -> null
          - value = "v1.2.6" -> null
        }
      - set {
          - name  = "orchestrationS3RoleArn" -> null
          - value = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration" -> null
        }
      + set {
          + name  = "image.tag"
          + value = "v1.2.8"
        }

        # (11 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["ingestion"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-ingestion"
      ~ metadata                   = [
          - {
              - app_version = "1.1.1"
              - chart       = "ingestion-chart"
              - name        = "phdi-playground-dev-ingestion"
              - namespace   = "default"
              - revision    = 14
              - values      = jsonencode(
                    {
                      - ecrBucketName          = "processed-ecr-files-dev"
                      - ecrViewerS3RoleArn     = "arn:aws:iam::339712971032:role/S3AccessRoleForEcrViewer"
                      - ecrViewerUrl           = "https://dibbs.cloud/ecr-viewer"
                      - fhirConverterUrl       = "https://dibbs.cloud/fhir-converter"
                      - image                  = {
                          - tag = "v1.2.6"
                        }
                      - ingestionUrl           = "https://dibbs.cloud/ingestion"
                      - messageParserUrl       = "https://dibbs.cloud/message-parser"
                      - nbsPubKey              = <<-EOT
                            -----BEGIN PUBLIC KEY-----
                            MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAqjrH9PprQCB5dX15zYfd
                            S6K2ezNi/ZOu8vKEhQuLqwHACy1iUt1Yyp2PZLIV7FVDgBHMMVWPVx3GJ2wEyaJw
                            MHkv6XNpUpWLhbs0V1T7o/OZfEIqcNua07OEoBxX9vhKIHtaksWdoMyKRXQJz0js
                            oWpawfOWxETnLqGvybT4yvY2RJhquTXLcLu90L4LdvIkADIZshaOtAU/OwI5ATcb
                            fE3ip15E6jIoUm7FAtfRiuncpI5l/LJPP6fvwf8QCbbUJBZklLqcUuf4qe/L/nIq
                            pIONb8KZFWPhnGeRZ9bwIcqYWt3LAAshQLSGEYl2PGXaqbkUD2XLETSKDjisxd0g
                            9j8bIMPgBKi+dBYcmBZnR7DxJe+vEDDw8prHG/+HRy5fim/BcibTKnIl8PR5yqHa
                            mWQo7N+xXhILdD9e33KLRgbg97+erHqvHlNMdwDhAfrBT+W6GCdPwp3cePPsbhsc
                            oGSHOUDhzyAujr0J8h5WmZDGUNWjGzWqubNZD8dBXB8x+9dDoWhfM82nw0pvAeKf
                            wJodvn3Qo8/S5hxJ6HyGkUTANKN8IxWh/6R5biET5BuztZP6jfPEaOAnt6sq+C38
                            hR9rUr59dP2BTlcJ19ZXobLwuJEa81S5BrcbDwYNOAzC8jl2EV1i4bQIwJJaY27X
                            Iynom6unaheZpS4DFIh2w9UCAwEAAQ==
                            -----END PUBLIC KEY-----
                        EOT
                      - orchestrationS3RoleArn = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration"
                      - smartyAuthId           = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken            = "AB5Bd7y9KGgxghGrD635"
                      - source                 = "s3"
                      - validationUrl          = "https://dibbs.cloud/validation"
                    }
                )
              - version     = "0.1.7"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-ingestion"
        # (26 unchanged attributes hidden)

      - set {
          - name  = "image.tag" -> null
          - value = "v1.2.6" -> null
        }
      - set {
          - name  = "orchestrationS3RoleArn" -> null
          - value = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration" -> null
        }
      + set {
          + name  = "image.tag"
          + value = "v1.2.8"
        }

        # (11 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["message-parser"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-message-parser"
      ~ metadata                   = [
          - {
              - app_version = "1.1.1"
              - chart       = "message-parser-chart"
              - name        = "phdi-playground-dev-message-parser"
              - namespace   = "default"
              - revision    = 14
              - values      = jsonencode(
                    {
                      - ecrBucketName          = "processed-ecr-files-dev"
                      - ecrViewerS3RoleArn     = "arn:aws:iam::339712971032:role/S3AccessRoleForEcrViewer"
                      - ecrViewerUrl           = "https://dibbs.cloud/ecr-viewer"
                      - fhirConverterUrl       = "https://dibbs.cloud/fhir-converter"
                      - image                  = {
                          - tag = "v1.2.6"
                        }
                      - ingestionUrl           = "https://dibbs.cloud/ingestion"
                      - messageParserUrl       = "https://dibbs.cloud/message-parser"
                      - nbsPubKey              = <<-EOT
                            -----BEGIN PUBLIC KEY-----
                            MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAqjrH9PprQCB5dX15zYfd
                            S6K2ezNi/ZOu8vKEhQuLqwHACy1iUt1Yyp2PZLIV7FVDgBHMMVWPVx3GJ2wEyaJw
                            MHkv6XNpUpWLhbs0V1T7o/OZfEIqcNua07OEoBxX9vhKIHtaksWdoMyKRXQJz0js
                            oWpawfOWxETnLqGvybT4yvY2RJhquTXLcLu90L4LdvIkADIZshaOtAU/OwI5ATcb
                            fE3ip15E6jIoUm7FAtfRiuncpI5l/LJPP6fvwf8QCbbUJBZklLqcUuf4qe/L/nIq
                            pIONb8KZFWPhnGeRZ9bwIcqYWt3LAAshQLSGEYl2PGXaqbkUD2XLETSKDjisxd0g
                            9j8bIMPgBKi+dBYcmBZnR7DxJe+vEDDw8prHG/+HRy5fim/BcibTKnIl8PR5yqHa
                            mWQo7N+xXhILdD9e33KLRgbg97+erHqvHlNMdwDhAfrBT+W6GCdPwp3cePPsbhsc
                            oGSHOUDhzyAujr0J8h5WmZDGUNWjGzWqubNZD8dBXB8x+9dDoWhfM82nw0pvAeKf
                            wJodvn3Qo8/S5hxJ6HyGkUTANKN8IxWh/6R5biET5BuztZP6jfPEaOAnt6sq+C38
                            hR9rUr59dP2BTlcJ19ZXobLwuJEa81S5BrcbDwYNOAzC8jl2EV1i4bQIwJJaY27X
                            Iynom6unaheZpS4DFIh2w9UCAwEAAQ==
                            -----END PUBLIC KEY-----
                        EOT
                      - orchestrationS3RoleArn = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration"
                      - smartyAuthId           = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken            = "AB5Bd7y9KGgxghGrD635"
                      - source                 = "s3"
                      - validationUrl          = "https://dibbs.cloud/validation"
                    }
                )
              - version     = "0.1.7"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-message-parser"
        # (26 unchanged attributes hidden)

      - set {
          - name  = "image.tag" -> null
          - value = "v1.2.6" -> null
        }
      - set {
          - name  = "orchestrationS3RoleArn" -> null
          - value = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration" -> null
        }
      + set {
          + name  = "image.tag"
          + value = "v1.2.8"
        }

        # (11 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["orchestration"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-orchestration"
      ~ metadata                   = [
          - {
              - app_version = ""
              - chart       = "orchestration"
              - name        = "phdi-playground-dev-orchestration"
              - namespace   = "default"
              - revision    = 10
              - values      = jsonencode(
                    {
                      - ecrBucketName          = "processed-ecr-files-dev"
                      - ecrViewerS3RoleArn     = "arn:aws:iam::339712971032:role/S3AccessRoleForEcrViewer"
                      - ecrViewerUrl           = "https://dibbs.cloud/ecr-viewer"
                      - fhirConverterUrl       = "https://dibbs.cloud/fhir-converter"
                      - image                  = {
                          - tag = "v1.2.6"
                        }
                      - ingestionUrl           = "https://dibbs.cloud/ingestion"
                      - messageParserUrl       = "https://dibbs.cloud/message-parser"
                      - nbsPubKey              = <<-EOT
                            -----BEGIN PUBLIC KEY-----
                            MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAqjrH9PprQCB5dX15zYfd
                            S6K2ezNi/ZOu8vKEhQuLqwHACy1iUt1Yyp2PZLIV7FVDgBHMMVWPVx3GJ2wEyaJw
                            MHkv6XNpUpWLhbs0V1T7o/OZfEIqcNua07OEoBxX9vhKIHtaksWdoMyKRXQJz0js
                            oWpawfOWxETnLqGvybT4yvY2RJhquTXLcLu90L4LdvIkADIZshaOtAU/OwI5ATcb
                            fE3ip15E6jIoUm7FAtfRiuncpI5l/LJPP6fvwf8QCbbUJBZklLqcUuf4qe/L/nIq
                            pIONb8KZFWPhnGeRZ9bwIcqYWt3LAAshQLSGEYl2PGXaqbkUD2XLETSKDjisxd0g
                            9j8bIMPgBKi+dBYcmBZnR7DxJe+vEDDw8prHG/+HRy5fim/BcibTKnIl8PR5yqHa
                            mWQo7N+xXhILdD9e33KLRgbg97+erHqvHlNMdwDhAfrBT+W6GCdPwp3cePPsbhsc
                            oGSHOUDhzyAujr0J8h5WmZDGUNWjGzWqubNZD8dBXB8x+9dDoWhfM82nw0pvAeKf
                            wJodvn3Qo8/S5hxJ6HyGkUTANKN8IxWh/6R5biET5BuztZP6jfPEaOAnt6sq+C38
                            hR9rUr59dP2BTlcJ19ZXobLwuJEa81S5BrcbDwYNOAzC8jl2EV1i4bQIwJJaY27X
                            Iynom6unaheZpS4DFIh2w9UCAwEAAQ==
                            -----END PUBLIC KEY-----
                        EOT
                      - orchestrationS3RoleArn = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration"
                      - smartyAuthId           = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken            = "AB5Bd7y9KGgxghGrD635"
                      - source                 = "s3"
                      - validationUrl          = "https://dibbs.cloud/validation"
                    }
                )
              - version     = "0.1.12"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-orchestration"
        # (26 unchanged attributes hidden)

      - set {
          - name  = "image.tag" -> null
          - value = "v1.2.6" -> null
        }
      - set {
          - name  = "orchestrationS3RoleArn" -> null
          - value = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration" -> null
        }
      + set {
          + name  = "image.tag"
          + value = "v1.2.8"
        }

        # (11 unchanged blocks hidden)
    }

  # module.eks.helm_release.building_blocks["validation"] will be updated in-place
  ~ resource "helm_release" "building_blocks" {
        id                         = "phdi-playground-dev-validation"
      ~ metadata                   = [
          - {
              - app_version = "v1.1.1"
              - chart       = "validation-chart"
              - name        = "phdi-playground-dev-validation"
              - namespace   = "default"
              - revision    = 14
              - values      = jsonencode(
                    {
                      - ecrBucketName          = "processed-ecr-files-dev"
                      - ecrViewerS3RoleArn     = "arn:aws:iam::339712971032:role/S3AccessRoleForEcrViewer"
                      - ecrViewerUrl           = "https://dibbs.cloud/ecr-viewer"
                      - fhirConverterUrl       = "https://dibbs.cloud/fhir-converter"
                      - image                  = {
                          - tag = "v1.2.6"
                        }
                      - ingestionUrl           = "https://dibbs.cloud/ingestion"
                      - messageParserUrl       = "https://dibbs.cloud/message-parser"
                      - nbsPubKey              = <<-EOT
                            -----BEGIN PUBLIC KEY-----
                            MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAqjrH9PprQCB5dX15zYfd
                            S6K2ezNi/ZOu8vKEhQuLqwHACy1iUt1Yyp2PZLIV7FVDgBHMMVWPVx3GJ2wEyaJw
                            MHkv6XNpUpWLhbs0V1T7o/OZfEIqcNua07OEoBxX9vhKIHtaksWdoMyKRXQJz0js
                            oWpawfOWxETnLqGvybT4yvY2RJhquTXLcLu90L4LdvIkADIZshaOtAU/OwI5ATcb
                            fE3ip15E6jIoUm7FAtfRiuncpI5l/LJPP6fvwf8QCbbUJBZklLqcUuf4qe/L/nIq
                            pIONb8KZFWPhnGeRZ9bwIcqYWt3LAAshQLSGEYl2PGXaqbkUD2XLETSKDjisxd0g
                            9j8bIMPgBKi+dBYcmBZnR7DxJe+vEDDw8prHG/+HRy5fim/BcibTKnIl8PR5yqHa
                            mWQo7N+xXhILdD9e33KLRgbg97+erHqvHlNMdwDhAfrBT+W6GCdPwp3cePPsbhsc
                            oGSHOUDhzyAujr0J8h5WmZDGUNWjGzWqubNZD8dBXB8x+9dDoWhfM82nw0pvAeKf
                            wJodvn3Qo8/S5hxJ6HyGkUTANKN8IxWh/6R5biET5BuztZP6jfPEaOAnt6sq+C38
                            hR9rUr59dP2BTlcJ19ZXobLwuJEa81S5BrcbDwYNOAzC8jl2EV1i4bQIwJJaY27X
                            Iynom6unaheZpS4DFIh2w9UCAwEAAQ==
                            -----END PUBLIC KEY-----
                        EOT
                      - orchestrationS3RoleArn = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration"
                      - smartyAuthId           = "98681a8c-89f6-f5b9-f14d-c832ce28e9b4"
                      - smartyToken            = "AB5Bd7y9KGgxghGrD635"
                      - source                 = "s3"
                      - validationUrl          = "https://dibbs.cloud/validation"
                    }
                )
              - version     = "0.1.7"
            },
        ] -> (known after apply)
        name                       = "phdi-playground-dev-validation"
        # (26 unchanged attributes hidden)

      - set {
          - name  = "image.tag" -> null
          - value = "v1.2.6" -> null
        }
      - set {
          - name  = "orchestrationS3RoleArn" -> null
          - value = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration" -> null
        }
      + set {
          + name  = "image.tag"
          + value = "v1.2.8"
        }

        # (11 unchanged blocks hidden)
    }

  # module.eks.kubectl_manifest.load_balancer_service_account will be updated in-place
  ~ resource "kubectl_manifest" "load_balancer_service_account" {
        id                      = "/api/v1/namespaces/kube-system/serviceaccounts/aws-load-balancer-controller"
        name                    = "aws-load-balancer-controller"
      ~ yaml_body               = (sensitive value)
        # (14 unchanged attributes hidden)
    }

  # module.route53.data.aws_lb.alb will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_lb" "alb" {
      + access_logs                                                  = (known after apply)
      + arn                                                          = (known after apply)
      + arn_suffix                                                   = (known after apply)
      + connection_logs                                              = (known after apply)
      + customer_owned_ipv4_pool                                     = (known after apply)
      + desync_mitigation_mode                                       = (known after apply)
      + dns_name                                                     = (known after apply)
      + dns_record_client_routing_policy                             = (known after apply)
      + drop_invalid_header_fields                                   = (known after apply)
      + enable_cross_zone_load_balancing                             = (known after apply)
      + enable_deletion_protection                                   = (known after apply)
      + enable_http2                                                 = (known after apply)
      + enable_tls_version_and_cipher_suite_headers                  = (known after apply)
      + enable_waf_fail_open                                         = (known after apply)
      + enable_xff_client_port                                       = (known after apply)
      + enforce_security_group_inbound_rules_on_private_link_traffic = (known after apply)
      + id                                                           = (known after apply)
      + idle_timeout                                                 = (known after apply)
      + internal                                                     = (known after apply)
      + ip_address_type                                              = (known after apply)
      + load_balancer_type                                           = (known after apply)
      + name                                                         = (known after apply)
      + preserve_host_header                                         = (known after apply)
      + security_groups                                              = (known after apply)
      + subnet_mapping                                               = (known after apply)
      + subnets                                                      = (known after apply)
      + tags                                                         = {
          + "ingress.k8s.aws/stack" = "phdi-playground-dev"
        }
      + vpc_id                                                       = (known after apply)
      + xff_header_processing_mode                                   = (known after apply)
      + zone_id                                                      = (known after apply)
    }

  # module.route53.aws_route53_record.alb will be updated in-place
  ~ resource "aws_route53_record" "alb" {
        id                               = "Z03589563KODV7RLSOEVV_dibbs.cloud_A"
        name                             = "dibbs.cloud"
        # (6 unchanged attributes hidden)

      ~ alias {
          ~ name                   = "k8s-phdiplaygrounddev-1f5c307cc0-153556051.us-east-1.elb.amazonaws.com" -> (known after apply)
          ~ zone_id                = "Z35SXDOTRQ7X7K" -> (known after apply)
            # (1 unchanged attribute hidden)
        }
    }

  # module.s3.aws_iam_policy.s3_bucket_orchestration_policy will be destroyed
  # (because aws_iam_policy.s3_bucket_orchestration_policy is not in configuration)
  - resource "aws_iam_policy" "s3_bucket_orchestration_policy" {
      - arn         = "arn:aws:iam::339712971032:policy/AWSS3IAMPolicyForOrchestration" -> null
      - description = "Policy for Orchestration and S3 in DIBBS" -> null
      - id          = "arn:aws:iam::339712971032:policy/AWSS3IAMPolicyForOrchestration" -> null
      - name        = "AWSS3IAMPolicyForOrchestration" -> null
      - path        = "/" -> null
      - policy      = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "s3:PutObjectAcl",
                          - "s3:PutObject",
                          - "s3:PostObjectAcl",
                          - "s3:PostObject",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:s3:::processed-ecr-files-dev/*",
                          - "arn:aws:s3:::processed-ecr-files-dev",
                        ]
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - policy_id   = "ANPAU6GDYSEMHJVL5VPGJ" -> null
      - tags        = {} -> null
      - tags_all    = {
          - "Environment" = "dev"
          - "Owner"       = "Skylight"
        } -> null
    }

  # module.s3.aws_iam_role.s3_role_for_ecr_viewer will be updated in-place
  ~ resource "aws_iam_role" "s3_role_for_ecr_viewer" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringEquals = {
                              ~ "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:sub" = [
                                  - "system:serviceaccount:default:orchestration",
                                    "system:serviceaccount:kube-system:aws-load-balancer-controller",
                                    # (1 unchanged element hidden)
                                ]
                                # (1 unchanged attribute hidden)
                            }
                        }
                        # (3 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id                    = "S3AccessRoleForEcrViewer"
        name                  = "S3AccessRoleForEcrViewer"
        tags                  = {}
        # (8 unchanged attributes hidden)
    }

  # module.s3.aws_iam_role.s3_role_for_orchestration will be destroyed
  # (because aws_iam_role.s3_role_for_orchestration is not in configuration)
  - resource "aws_iam_role" "s3_role_for_orchestration" {
      - arn                   = "arn:aws:iam::339712971032:role/S3AccessRoleForOrchestration" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRoleWithWebIdentity"
                      - Condition = {
                          - StringEquals = {
                              - "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:aud" = "sts.amazonaws.com"
                              - "oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33:sub" = [
                                  - "system:serviceaccount:default:orchestration",
                                  - "system:serviceaccount:kube-system:aws-load-balancer-controller",
                                  - "system:serviceaccount:default:ecr-viewer",
                                ]
                            }
                        }
                      - Effect    = "Allow"
                      - Principal = {
                          - Federated = "arn:aws:iam::339712971032:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/FD74D748539038C56F947D4FE2130D33"
                        }
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2024-03-05T21:15:53Z" -> null
      - force_detach_policies = false -> null
      - id                    = "S3AccessRoleForOrchestration" -> null
      - managed_policy_arns   = [
          - "arn:aws:iam::339712971032:policy/AWSS3IAMPolicyForOrchestration",
        ] -> null
      - max_session_duration  = 3600 -> null
      - name                  = "S3AccessRoleForOrchestration" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - tags_all              = {
          - "Environment" = "dev"
          - "Owner"       = "Skylight"
        } -> null
      - unique_id             = "AROAU6GDYSEMKC4GKFPDR" -> null
    }

  # module.s3.aws_iam_role_policy_attachment.s3_bucket_orchestration_policy will be destroyed
  # (because aws_iam_role_policy_attachment.s3_bucket_orchestration_policy is not in configuration)
  - resource "aws_iam_role_policy_attachment" "s3_bucket_orchestration_policy" {
      - id         = "S3AccessRoleForOrchestration-20240305211553649200000002" -> null
      - policy_arn = "arn:aws:iam::339712971032:policy/AWSS3IAMPolicyForOrchestration" -> null
      - role       = "S3AccessRoleForOrchestration" -> null
    }

  # module.eks.module.eks_blueprints_addons.module.karpenter.helm_release.this[0] will be updated in-place
  ~ resource "helm_release" "this" {
        id                         = "karpenter"
        name                       = "karpenter"
      ~ repository_password        = (sensitive value)
        # (30 unchanged attributes hidden)

        # (8 unchanged blocks hidden)
    }

Plan: 5 to add, 11 to change, 3 to destroy.
```
