### PR TITLE
Adding refiner and TCR to Terraform

### DIFF
--- a/terraform/aws/implementation/manifests/ingressWithCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithCognito.yaml
@@ -62,7 +62,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-trigger-code-reference-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/manifests/ingressWithCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithCognito.yaml
@@ -62,7 +62,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-reference-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-trigger-code-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/manifests/ingressWithCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithCognito.yaml
@@ -62,7 +62,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-reference-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-trigger-code-reference-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/manifests/ingressWithCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithCognito.yaml
@@ -62,7 +62,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-trigger-code-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-reference-tcr-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/manifests/ingressWithCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithCognito.yaml
@@ -51,6 +51,20 @@ spec:
                 name: phdi-playground-${terraform_workspace}-orchestration-orchestration-service
                 port:
                   number: 8080
+          - path: /message-refiner
+            pathType: Prefix
+            backend:
+              service:
+                name: phdi-playground-${terraform_workspace}-message-refiner-message-refiner-service
+                port:
+                  number: 8080
+          - path: /trigger-code-reference
+            pathType: Prefix
+            backend:
+              service:
+                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-reference-service
+                port:
+                  number: 8080
           - path: /ecr-viewer
             pathType: Prefix
             backend:

--- a/terraform/aws/implementation/manifests/ingressWithCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithCognito.yaml
@@ -62,7 +62,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-reference-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
@@ -47,6 +47,20 @@ spec:
                 name: phdi-playground-${terraform_workspace}-orchestration-orchestration-service
                 port:
                   number: 8080
+          - path: /message-refiner
+            pathType: Prefix
+            backend:
+              service:
+                name: phdi-playground-${terraform_workspace}-message-refiner-message-refiner-service
+                port:
+                  number: 8080
+          - path: /trigger-code-reference
+            pathType: Prefix
+            backend:
+              service:
+                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-reference-service
+                port:
+                  number: 8080
           - path: /ecr-viewer
             pathType: Prefix
             backend:

--- a/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
@@ -58,7 +58,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-trigger-code-reference-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
@@ -58,7 +58,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-reference-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-trigger-code-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
@@ -58,7 +58,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-trigger-code-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-reference-tcr-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
@@ -58,7 +58,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-reference-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-trigger-code-reference-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
+++ b/terraform/aws/implementation/manifests/ingressWithoutCognito.yaml
@@ -58,7 +58,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-service
+                name: phdi-playground-${terraform_workspace}-trigger-code-reference-trigger-code-reference-service
                 port:
                   number: 8080
           - path: /ecr-viewer

--- a/terraform/aws/implementation/modules/eks/main.tf
+++ b/terraform/aws/implementation/modules/eks/main.tf
@@ -357,7 +357,7 @@ resource "helm_release" "building_blocks" {
     value = "https://${var.domain_name}/trigger-code-reference"
   }
 
-   set {
+  set {
     name  = "messageRefiner"
     value = "https://${var.domain_name}/message-refiner"
   }

--- a/terraform/aws/implementation/modules/eks/main.tf
+++ b/terraform/aws/implementation/modules/eks/main.tf
@@ -353,6 +353,16 @@ resource "helm_release" "building_blocks" {
   }
 
   set {
+    name  = "triggerCodeReferenceUrl"
+    value = "https://${var.domain_name}/trigger-code-reference"
+  }
+
+   set {
+    name  = "messageRefiner"
+    value = "https://${var.domain_name}/message-refiner"
+  }
+
+  set {
     name  = "ecrBucketName"
     value = var.ecr_bucket_name
   }

--- a/terraform/aws/implementation/modules/eks/variables.tf
+++ b/terraform/aws/implementation/modules/eks/variables.tf
@@ -27,13 +27,15 @@ variable "private_subnet_ids" {
 variable "services_to_chart" {
   type = map(string)
   default = {
-    fhir-converter = "fhir-converter",
-    ingestion      = "ingestion",
-    message-parser = "message-parser",
-    orchestration  = "orchestration",
-    validation     = "validation",
-    ecr-viewer     = "ecr-viewer",
-    tefca-viewer   = "tefca-viewer",
+    fhir-converter         = "fhir-converter",
+    ingestion              = "ingestion",
+    message-parser         = "message-parser",
+    orchestration          = "orchestration",
+    validation             = "validation",
+    ecr-viewer             = "ecr-viewer",
+    tefca-viewer           = "tefca-viewer",
+    message-refiner        = "message-refiner",
+    trigger-code-reference = "trigger-code-reference"
   }
 }
 

--- a/terraform/azure/implementation/main.tf
+++ b/terraform/azure/implementation/main.tf
@@ -25,13 +25,15 @@ locals {
 variable "services_to_chart" {
   type = map(string)
   default = {
-    fhir-converter = "fhir-converter-chart",
-    ingestion      = "ingestion-chart",
-    ingress        = "ingress-chart",
-    message-parser = "message-parser-chart",
-    orchestration  = "orchestration",
-    validation     = "validation-chart"
-    tefca-viewer   = "tefca-viewer"
+    fhir-converter         = "fhir-converter-chart",
+    ingestion              = "ingestion-chart",
+    ingress                = "ingress-chart",
+    message-parser         = "message-parser-chart",
+    orchestration          = "orchestration",
+    validation             = "validation-chart"
+    tefca-viewer           = "tefca-viewer",
+    message-refiner        = "message-refiner",
+    trigger-code-reference = "trigger-code-reference"
   }
 }
 


### PR DESCRIPTION
# PULL REQUEST

## Summary
This will add the message-refiner and trigger-code-reference services to the deployment of both the aws and azure terraform. Work is done in tandem with the addition of these services: https://github.com/CDCgov/phdi-charts/pull/46, so will try to run once that is done.


## Related Issue
Fixes #1901

## Additional Information
Anything else the review team should know?

[//]: # (PR title: Remember to name your PR descriptively!)
