### PR TITLE
Update aws provider version to eliminate conflicts.

### DIFF
--- a/terraform/aws/implementation/backend.tf
+++ b/terraform/aws/implementation/backend.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "=5.31.0"
+      version = "=5.61.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/terraform/aws/setup/main.tf
+++ b/terraform/aws/setup/main.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "=5.31.0"
+      version = "=5.61.0"
     }
   }
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary
Updates AWS provider version to 5.61.0.

## Related Issue
N/A

## Additional Information
It appears that the existing TF providers in AWS updated in such a way over the weekend to introduce a version conflict when the latest PR was merged this morning. This pull request updates the `hashicorp/aws` provider to the latest version, which resolves the constraint violation.

[//]: # (PR title: Remember to name your PR descriptively!)
