### PR TITLE
Convert random_string to random_password in RDS module.

### DIFF
--- a/terraform/aws/implementation/modules/rds/main.tf
+++ b/terraform/aws/implementation/modules/rds/main.tf
@@ -6,7 +6,7 @@ resource "aws_db_instance" "tefca-viewer-db" {
   engine                    = var.engine_type
   engine_version            = var.engine_version
   username                  = var.db_username
-  password                  = random_string.setup_rds_password.result
+  password                  = random_password.setup_rds_password.result
   db_subnet_group_name      = aws_db_subnet_group.this.name
   vpc_security_group_ids    = [aws_security_group.ds_sg.id]
   parameter_group_name      = aws_db_parameter_group.this.name
@@ -64,7 +64,7 @@ resource "aws_db_subnet_group" "this" {
 
 # TODO: Update for Production to AWS Secrets Manager 
 # This resource's attribute(s) default value is true 
-resource "random_string" "setup_rds_password" {
+resource "random_password" "setup_rds_password" {
   length = 13 #update as needed
 
   # Character set that excludes problematic characters like quotes, backslashes, etc.


### PR DESCRIPTION
# PULL REQUEST

## Summary
Previously, the RDS terraform module used `random_string` to generate a password for the database. This is dangerous, as `random_string` is not marked as sensitive. Values generated using this resource can be viewed in the console, and might be recovered by a malicious actor.

This PR replaces `random_string` with `random_password`, which guarantees handling as a sensitive value.

## Related Issue
Fixes #89 

## Additional Information
See below for an example of how `random_string` is currently handled. It appears as though Terraform is automatically converting the object for safety, but this code change should guarantee proper handling.
![Screenshot 2024-10-08 at 1 00 21 PM](https://github.com/user-attachments/assets/7fd2d61b-d622-431f-bc4c-e65a62aefede)


[//]: # (PR title: Remember to name your PR descriptively!)
