### PR TITLE
Flyway Configurations

### DIFF
--- a/terraform/aws/implementation/modules/rds/main.tf
+++ b/terraform/aws/implementation/modules/rds/main.tf
@@ -75,5 +75,5 @@ resource "random_password" "setup_rds_password" {
   length = 13 #update as needed
 
   # Character set that excludes problematic characters like quotes, backslashes, etc.
-  override_special = "()[]{}"
+  override_special = "[]{}"
 }

--- a/terraform/aws/implementation/modules/rds/output.tf
+++ b/terraform/aws/implementation/modules/rds/output.tf
@@ -8,7 +8,7 @@ output "tefca_db_connection_string" {
 }
 
 output "tefca_jdbc_db_url" {
-  value     = "jdbc:postgres://${aws_db_instance.tefca-viewer-db.endpoint}/${aws_db_instance.tefca-viewer-db.db_name}"
+  value     = "jdbc:postgresql://${aws_db_instance.tefca-viewer-db.endpoint}/${aws_db_instance.tefca-viewer-db.db_name}"
   sensitive = true
 }
 


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Modified the `tefca_jdbc_db_url` to match the required string for a successful flyway connection with the pod
- Removed `()` from the special characters lists due to postgres throwing a syntax error message during login


[//]: # (PR title: Remember to name your PR descriptively!)
